### PR TITLE
feat(about): add About dialog with build-time version

### DIFF
--- a/.cursor/rules/components.mdc
+++ b/.cursor/rules/components.mdc
@@ -10,31 +10,32 @@ All components live in `src/components/`. They read from the Zustand store via `
 
 ## Responsibilities
 
-| Component                 | Role                                                                                                       |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `GraphCanvas`             | React Flow canvas; wires node/edge types, store change handlers, saves viewport on move.                   |
-| `ConceptNode`             | Custom node; heatmap overlay, confidence underline, dashed when due, handles `out`/`in`.                   |
-| `NessoConnectionLine`     | Dragging preview with same quadratic geometry as `NessoEdge`.                                              |
-| `NessoEdge`               | Custom edge; line style + glyph from `EdgeTypeDef`; respects `edgeEncoding` setting.                       |
-| `GlyphSVG`                | SVG renderer for the 16 `GlyphKind` icons on edges.                                                        |
-| `NessoMark`               | Inline SVG brandmark (nexus graph); `currentColor` + `var(--accent)` hub; sources in `public/icon/`.       |
-| `TopBar`                  | Graph title + counts; Review pill; `GraphIO` (⋯) menu.                                                     |
-| `Sidebar`                 | Brand, collapse, search (⌘K), graph list, recent concepts, display toggles, Settings.                      |
-| `SearchDialog`            | Command-palette (⌘K); selects node and recenters viewport; closes on Enter/Escape.                         |
-| `GraphIO`                 | ⋯ menu: relation types, JSON export/import, shortcuts. Callbacks via `TopBar`.                             |
-| `BottomDock`              | Fit, zoom in/out/%, add concept.                                                                           |
-| `Inspector`               | Selected node (edit text, FSRS stats) or edge (type chips).                                                |
-| `RelationPicker`          | Dropdown grid for `EdgeTypeName`, grouped by `EdgeCategory`.                                               |
-| `RelationTypesDialog`     | Modal reference for all relation types.                                                                    |
-| `MentorBubble`            | FAB + Socratic chat card; `mentorPanelExpanded` persisted; header **New chat** (reload). See `mentor.mdc`. |
-| `SocratesGlyph`           | SVG avatar for the mentor FAB.                                                                             |
-| `ReviewMode`              | Full-screen FSRS review; queues due nodes; Again/Hard/Good/Easy → `recordStudyRating`.                     |
-| `SettingsDialog`          | Tabbed modal: Appearance, AI, Review (FSRS), Data (erase local storage + reload). Opened via ⌘,.           |
-| `ShortcutsDialog`         | Keyboard shortcut reference modal. Opened via `?` or `GraphIO`.                                            |
-| `CloseButton`             | Icon dismiss shared by modal headers.                                                                      |
-| `ActionBanner`            | Banner with message + pill actions (persistent notices, not auto-dismiss toasts). `App.tsx` stacks banners in a top-right fixed container.            |
-| `GraphFileConflictBanner` | Desktop file-watch conflict; wraps `ActionBanner` with reload / keep-local actions.                        |
-| `UpdateBanner`            | Desktop auto-update notice; wraps `ActionBanner` with install / later / retry / restart actions (see `useDesktopUpdater`).                          |
+| Component                 | Role                                                                                                                                       |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `GraphCanvas`             | React Flow canvas; wires node/edge types, store change handlers, saves viewport on move.                                                   |
+| `ConceptNode`             | Custom node; heatmap overlay, confidence underline, dashed when due, handles `out`/`in`.                                                   |
+| `NessoConnectionLine`     | Dragging preview with same quadratic geometry as `NessoEdge`.                                                                              |
+| `NessoEdge`               | Custom edge; line style + glyph from `EdgeTypeDef`; respects `edgeEncoding` setting.                                                       |
+| `GlyphSVG`                | SVG renderer for the 16 `GlyphKind` icons on edges.                                                                                        |
+| `NessoMark`               | Inline SVG brandmark (nexus graph); `currentColor` + `var(--accent)` hub; sources in `public/icon/`.                                       |
+| `TopBar`                  | Graph title + counts; Review pill; `GraphIO` (⋯) menu.                                                                                     |
+| `Sidebar`                 | Brand, collapse, search (⌘K), graph list, recent concepts, display toggles, Settings, About (info).                                        |
+| `SearchDialog`            | Command-palette (⌘K); selects node and recenters viewport; closes on Enter/Escape.                                                         |
+| `GraphIO`                 | ⋯ menu: relation types, JSON export/import, shortcuts, About. Callbacks via `TopBar`.                                                      |
+| `BottomDock`              | Fit, zoom in/out/%, add concept.                                                                                                           |
+| `Inspector`               | Selected node (edit text, FSRS stats) or edge (type chips).                                                                                |
+| `RelationPicker`          | Dropdown grid for `EdgeTypeName`, grouped by `EdgeCategory`.                                                                               |
+| `RelationTypesDialog`     | Modal reference for all relation types.                                                                                                    |
+| `MentorBubble`            | FAB + Socratic chat card; `mentorPanelExpanded` persisted; header **New chat** (reload). See `mentor.mdc`.                                 |
+| `SocratesGlyph`           | SVG avatar for the mentor FAB.                                                                                                             |
+| `ReviewMode`              | Full-screen FSRS review; queues due nodes; Again/Hard/Good/Easy → `recordStudyRating`.                                                     |
+| `SettingsDialog`          | Tabbed modal: Appearance, AI, Review (FSRS), Data (erase local storage + reload). Opened via ⌘,.                                           |
+| `AboutDialog`             | Modal with app version, tagline, and external links; opened from native menu (`menu:about`), Sidebar info button, or ⋯ menu.               |
+| `ShortcutsDialog`         | Keyboard shortcut reference modal. Opened via `?` or `GraphIO`.                                                                            |
+| `CloseButton`             | Icon dismiss shared by modal headers.                                                                                                      |
+| `ActionBanner`            | Banner with message + pill actions (persistent notices, not auto-dismiss toasts). `App.tsx` stacks banners in a top-right fixed container. |
+| `GraphFileConflictBanner` | Desktop file-watch conflict; wraps `ActionBanner` with reload / keep-local actions.                                                        |
+| `UpdateBanner`            | Desktop auto-update notice; wraps `ActionBanner` with install / later / retry / restart actions (see `useDesktopUpdater`).                 |
 
 ## Layout
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Added
+
+- **About:** dialog "About Nesso" (versione, descrizione, link a GitHub/sito/changelog/licenza), raggiungibile dal menu nativo desktop (app menu su macOS, Help su Windows/Linux), dal pulsante info nella Sidebar e dal menu ⋯. La versione è iniettata a build-time da `package.json`.
+
 ## [0.1.0-alpha.26] - 2026-06-02
 
 ### Added

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,9 +16,72 @@ pub fn run() {
         .setup(|app| {
             #[cfg(desktop)]
             {
+                use tauri::menu::{MenuBuilder, MenuItemBuilder, SubmenuBuilder};
+                use tauri::{Emitter, Manager};
+
                 app.handle()
                     .plugin(tauri_plugin_updater::Builder::new().build())?;
                 app.handle().plugin(tauri_plugin_process::init())?;
+
+                let about_i = MenuItemBuilder::with_id("about", "About Nesso").build(app)?;
+
+                let mut menu = MenuBuilder::new(app);
+
+                #[cfg(target_os = "macos")]
+                {
+                    let app_menu = SubmenuBuilder::new(app, "Nesso")
+                        .item(&about_i)
+                        .separator()
+                        .services()
+                        .separator()
+                        .hide()
+                        .hide_others()
+                        .show_all()
+                        .separator()
+                        .quit()
+                        .build()?;
+                    menu = menu.item(&app_menu);
+                }
+
+                let edit_menu = SubmenuBuilder::new(app, "Edit")
+                    .undo()
+                    .redo()
+                    .separator()
+                    .cut()
+                    .copy()
+                    .paste()
+                    .select_all()
+                    .build()?;
+                menu = menu.item(&edit_menu);
+
+                let window_menu = SubmenuBuilder::new(app, "Window")
+                    .minimize()
+                    .separator()
+                    .close_window()
+                    .build()?;
+                menu = menu.item(&window_menu);
+
+                // No Help submenu on macOS — About already lives in the app menu.
+                #[cfg(not(target_os = "macos"))]
+                {
+                    let help_menu = SubmenuBuilder::new(app, "Help")
+                        .item(&about_i)
+                        .separator()
+                        .build()?;
+                    menu = menu.item(&help_menu);
+                }
+
+                let menu = menu.build()?;
+                app.set_menu(menu)?;
+
+                let about_id = about_i.id().clone();
+                app.on_menu_event(move |app, event| {
+                    if about_id == event.id() {
+                        if let Some(w) = app.get_webview_window("main") {
+                            let _ = w.emit("menu:about", ());
+                        }
+                    }
+                });
             }
             if cfg!(debug_assertions) {
                 app.handle().plugin(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,8 @@ import { MentorBubble } from './components/MentorBubble'
 import { ReviewMode } from './components/ReviewMode'
 import { ShortcutsDialog } from './components/ShortcutsDialog'
 import { SettingsDialog } from './components/SettingsDialog'
+import { AboutDialog } from './components/AboutDialog'
+import { isDesktop } from '@/lib/isDesktop'
 import { SearchDialog } from './components/SearchDialog'
 import { useGraphStore, selectedNodeSelector, selectedEdgeSelector } from './store/graph'
 import { useAutoSave } from './hooks/useAutoSave'
@@ -41,6 +43,7 @@ function AppInner() {
   const [showSettings, setShowSettings] = useState(false)
   const [showRelationTypes, setShowRelationTypes] = useState(false)
   const [showSearch, setShowSearch] = useState(false)
+  const [showAbout, setShowAbout] = useState(false)
 
   const {
     nodes,
@@ -74,6 +77,22 @@ function AppInner() {
 
   useAutoSave()
   useGraphFileWatch()
+
+  useEffect(() => {
+    if (!isDesktop()) return
+    let unlisten: (() => void) | undefined
+    let cancelled = false
+    void (async () => {
+      const { listen } = await import('@tauri-apps/api/event')
+      if (cancelled) return
+      unlisten = await listen('menu:about', () => setShowAbout(true))
+      if (cancelled) unlisten()
+    })()
+    return () => {
+      cancelled = true
+      unlisten?.()
+    }
+  }, [])
 
   const [sidebarPanelWidth, setSidebarPanelWidth] = useState(readSidebarWidth)
   useEffect(() => {
@@ -246,6 +265,7 @@ function AppInner() {
         setShowSettings(false)
         setShowRelationTypes(false)
         setShowSearch(false)
+        setShowAbout(false)
         return
       }
       if (e.key === '?') {
@@ -311,6 +331,10 @@ function AppInner() {
         handleAddConcept()
         return
       }
+      if (e.key.toLowerCase() === 'f' && !e.metaKey && !e.ctrlKey && !e.altKey && !showReview) {
+        fitView()
+        return
+      }
       if (e.key === '/') {
         e.preventDefault()
       }
@@ -325,6 +349,7 @@ function AppInner() {
     deleteSelection,
     requestEditNode,
     handleAddConcept,
+    fitView,
     showReview,
   ])
 
@@ -345,6 +370,7 @@ function AppInner() {
         onCollapse={() => setSidebarCollapsed(true)}
         onSearch={() => setShowSearch((s) => !s)}
         onSettings={() => setShowSettings((s) => !s)}
+        onAbout={() => setShowAbout(true)}
         zoom={zoom}
         width={sidebarPanelWidth}
         onWidthChange={(w) => setSidebarPanelWidth(clampSidebarWidth(w))}
@@ -357,6 +383,7 @@ function AppInner() {
         onReview={() => setShowReview(true)}
         onRelationTypes={() => setShowRelationTypes((s) => !s)}
         onShortcuts={() => setShowShortcuts((s) => !s)}
+        onAbout={() => setShowAbout(true)}
       />
 
       <RelationTypesDialog open={showRelationTypes} onClose={() => setShowRelationTypes(false)} />
@@ -378,6 +405,7 @@ function AppInner() {
       <ReviewMode open={showReview} onClose={() => setShowReview(false)} />
       <ShortcutsDialog open={showShortcuts} onClose={() => setShowShortcuts(false)} />
       <SettingsDialog open={showSettings} onClose={() => setShowSettings(false)} />
+      <AboutDialog open={showAbout} onClose={() => setShowAbout(false)} />
       <SearchDialog
         open={showSearch}
         onClose={() => setShowSearch(false)}

--- a/src/components/AboutDialog.tsx
+++ b/src/components/AboutDialog.tsx
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: MIT
+import type { CSSProperties, ReactNode } from 'react'
+import { CloseButton } from './CloseButton'
+import { NessoMark } from './NessoMark'
+import {
+  APP_VERSION,
+  CHANGELOG_URL,
+  DOCS_URL,
+  LICENSE_URL,
+  openExternal,
+  REPO_URL,
+  WEBSITE_URL,
+} from '@/data/appInfo'
+import { useT } from '@/i18n'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+}
+
+const linkRow: CSSProperties = {
+  appearance: 'none',
+  display: 'flex',
+  alignItems: 'center',
+  gap: 10,
+  width: '100%',
+  padding: '11px 14px',
+  border: 0,
+  background: 'var(--bg-card)',
+  cursor: 'default',
+  textAlign: 'left',
+  font: "500 13px 'Inter', system-ui",
+  color: 'var(--ink-2)',
+  transition: 'background 0.12s, color 0.12s',
+}
+
+export function AboutDialog({ open, onClose }: Props) {
+  const t = useT()
+
+  if (!open) return null
+
+  const links: { label: string; url: string; icon: ReactNode }[] = [
+    { label: t.about.links.github, url: REPO_URL, icon: <GithubIcon /> },
+    { label: t.about.links.website, url: WEBSITE_URL, icon: <GlobeIcon /> },
+    { label: t.about.links.documentation, url: DOCS_URL, icon: <BookIcon /> },
+    { label: t.about.links.changelog, url: CHANGELOG_URL, icon: <ChangelogIcon /> },
+    { label: t.about.links.license, url: LICENSE_URL, icon: <LicenseIcon /> },
+  ]
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'absolute',
+        inset: 0,
+        zIndex: 75,
+        background: 'rgba(20, 18, 14, 0.55)',
+        backdropFilter: 'blur(6px)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          position: 'relative',
+          filter: 'var(--drop-shadow-lg)',
+        }}
+      >
+        <div style={{ position: 'absolute', top: 12, right: 12, zIndex: 1 }}>
+          <CloseButton large onClick={onClose} />
+        </div>
+        <div
+          style={{
+            width: 380,
+            maxWidth: '94vw',
+            background: 'var(--bg-card)',
+            border: '0.5px solid var(--line)',
+            borderRadius: 18,
+            padding: '32px 28px 24px',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+          }}
+        >
+          <div style={{ color: 'var(--ink)', lineHeight: 0 }} aria-hidden>
+            <NessoMark size={44} />
+          </div>
+          <div
+            style={{
+              marginTop: 14,
+              font: "500 20px 'Inter', ui-sans-serif",
+              color: 'var(--ink)',
+              letterSpacing: '-0.02em',
+            }}
+          >
+            Nesso
+          </div>
+          <span
+            style={{
+              marginTop: 8,
+              font: "400 12px 'JetBrains Mono', ui-monospace",
+              color: 'var(--ink-4)',
+            }}
+          >
+            {t.about.version(APP_VERSION)}
+          </span>
+          <p
+            style={{
+              margin: '14px 0 0',
+              font: "400 13px 'Inter', ui-sans-serif",
+              color: 'var(--ink-3)',
+              textAlign: 'center',
+              lineHeight: 1.45,
+              maxWidth: 300,
+            }}
+          >
+            {t.about.tagline}
+          </p>
+          <div
+            style={{
+              width: '100%',
+              marginTop: 22,
+              padding: 1,
+              borderRadius: 12,
+              background: 'var(--line)',
+            }}
+          >
+            <div style={{ borderRadius: 11, overflow: 'hidden' }}>
+              {links.map(({ label, url, icon }, i) => (
+                <button
+                  key={url}
+                  type="button"
+                  style={{
+                    ...linkRow,
+                    borderTop: i > 0 ? '0.5px solid var(--line)' : 'none',
+                  }}
+                  onClick={() => void openExternal(url)}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.background = 'var(--paper-deep)'
+                    e.currentTarget.style.color = 'var(--ink)'
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.background = 'var(--bg-card)'
+                    e.currentTarget.style.color = 'var(--ink-2)'
+                  }}
+                >
+                  <span style={{ flexShrink: 0, lineHeight: 0 }} aria-hidden>
+                    {icon}
+                  </span>
+                  <span
+                    style={{
+                      flex: 1,
+                      minWidth: 0,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {label}
+                  </span>
+                  <span style={{ flexShrink: 0, lineHeight: 0, opacity: 0.55 }} aria-hidden>
+                    <ExternalArrow />
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function GithubIcon() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 16 16" fill="currentColor" aria-hidden>
+      <path d="M8 0c4.42 0 8 3.58 8 8a8.01 8.01 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.04-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.27-.82 2.15 0 3.07 1.87 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.46-.55.38A8 8 0 0 1 0 8c0-4.42 3.58-8 8-8Z" />
+    </svg>
+  )
+}
+
+function BookIcon() {
+  return (
+    <svg
+      width="15"
+      height="15"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M8 4.2C7.3 3.6 6.3 3.3 5 3.3H2.5v8.4H5c1.3 0 2.3.3 3 .9 .7-.6 1.7-.9 3-.9h2.5V3.3H11c-1.3 0-2.3.3-3 .9Z" />
+      <path d="M8 4.2v8.4" />
+    </svg>
+  )
+}
+
+function GlobeIcon() {
+  return (
+    <svg
+      width="15"
+      height="15"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="8" cy="8" r="6.5" />
+      <path d="M1.5 8h13" />
+      <path d="M8 1.5c1.9 1.7 2.9 4.1 2.9 6.5S9.9 12.8 8 14.5C6.1 12.8 5.1 10.4 5.1 8S6.1 3.2 8 1.5Z" />
+    </svg>
+  )
+}
+
+function ChangelogIcon() {
+  return (
+    <svg
+      width="15"
+      height="15"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="3" y="2" width="10" height="12" rx="1.5" />
+      <path d="M5.5 5.5h5M5.5 8h5M5.5 10.5h3" />
+    </svg>
+  )
+}
+
+function LicenseIcon() {
+  return (
+    <svg
+      width="15"
+      height="15"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M8 2.5v11M4 4.5h8M5.5 13.5h5" />
+      <path d="M4 4.5 2 9h4L4 4.5zM12 4.5 10 9h4l-2-4.5z" />
+    </svg>
+  )
+}
+
+function ExternalArrow() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M5 11 11 5M6 5h5v5" />
+    </svg>
+  )
+}

--- a/src/components/GraphIO.tsx
+++ b/src/components/GraphIO.tsx
@@ -15,9 +15,10 @@ import {
 interface Props {
   onRelationTypes: () => void
   onShortcuts: () => void
+  onAbout: () => void
 }
 
-export function GraphIO({ onRelationTypes, onShortcuts }: Props) {
+export function GraphIO({ onRelationTypes, onShortcuts, onAbout }: Props) {
   const t = useT()
   const { nodes, edges, graphList, currentGraphId, graphDisplay, importGraph } = useGraphStore()
   const [open, setOpen] = useState(false)
@@ -286,6 +287,29 @@ export function GraphIO({ onRelationTypes, onShortcuts }: Props) {
               </svg>
             }
             label={t.graphIO.keyboardShortcuts}
+          />
+          <MenuItem
+            onClick={() => {
+              onAbout()
+              setOpen(false)
+            }}
+            icon={
+              <svg
+                width="13"
+                height="13"
+                viewBox="0 0 16 16"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.4"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <circle cx="8" cy="8" r="6.25" />
+                <path d="M8 7.25v3.25" />
+                <circle cx="8" cy="5.2" r="0.1" />
+              </svg>
+            }
+            label={t.graphIO.about}
           />
         </div>
       )}

--- a/src/components/ShortcutsDialog.tsx
+++ b/src/components/ShortcutsDialog.tsx
@@ -27,6 +27,7 @@ export function ShortcutsDialog({ open, onClose }: Props) {
       rows: [
         { keys: [mod, 'K'], label: t.shortcuts.rows.search },
         { keys: ['N'], label: t.shortcuts.rows.addConcept },
+        { keys: ['F'], label: t.shortcuts.rows.fit },
         { keys: ['R'], label: t.shortcuts.rows.review },
         { keys: ['Del'], label: t.shortcuts.rows.delete },
         { keys: [mod, 'C'], label: t.shortcuts.rows.copy },

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,9 +3,8 @@ import { useState, useRef, useEffect, type MouseEvent as ReactMouseEvent } from 
 import { useGraphStore } from '@/store/graph'
 import { useT } from '@/i18n'
 import { NessoMark } from './NessoMark'
+import { WEBSITE_URL } from '@/data/appInfo'
 import { SIDEBAR_WIDTH_STORAGE_KEY } from '@/data/storageKeys'
-
-const NESSO_WEBSITE_URL = 'https://nesso.how'
 
 export const SIDEBAR_MIN_WIDTH = 180
 export const SIDEBAR_MAX_WIDTH = 380
@@ -38,6 +37,7 @@ interface Props {
   onCollapse: () => void
   onSearch: () => void
   onSettings: () => void
+  onAbout: () => void
   zoom: number
   width: number
   onWidthChange: (w: number) => void
@@ -48,6 +48,7 @@ export function Sidebar({
   onCollapse,
   onSearch,
   onSettings,
+  onAbout,
   zoom,
   width,
   onWidthChange,
@@ -175,7 +176,7 @@ export function Sidebar({
             }}
           >
             <a
-              href={NESSO_WEBSITE_URL}
+              href={WEBSITE_URL}
               target="_blank"
               rel="noopener noreferrer"
               title={t.sidebar.websiteLinkTitle}
@@ -560,7 +561,7 @@ export function Sidebar({
             )}
           </div>
 
-          {/* Footer — Settings */}
+          {/* Footer — Settings + About */}
           <div
             style={{
               padding: '8px 8px',
@@ -568,59 +569,88 @@ export function Sidebar({
               flexShrink: 0,
             }}
           >
-            <button
-              type="button"
-              onClick={onSettings}
-              title={t.sidebar.settingsTitle}
+            <div
               style={{
-                appearance: 'none',
-                border: 0,
-                background: 'transparent',
                 display: 'flex',
                 alignItems: 'center',
-                gap: 9,
-                width: '100%',
-                padding: '7px 9px',
-                borderRadius: 6,
-                cursor: 'default',
-                font: "500 13px 'Inter', ui-sans-serif",
-                color: 'var(--ink-3)',
-                textAlign: 'left',
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.background = 'var(--paper-deep)'
-                e.currentTarget.style.color = 'var(--ink)'
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.background = 'transparent'
-                e.currentTarget.style.color = 'var(--ink-3)'
+                justifyContent: 'space-between',
+                gap: 6,
               }}
             >
-              <svg
-                width="14"
-                height="14"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                style={{ flexShrink: 0 }}
-              >
-                <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.38a2 2 0 0 0-.73-2.73l-.15-.1a2 2 0 0 1-1-1.72v-.51a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
-                <circle cx="12" cy="12" r="3" />
-              </svg>
-              {t.sidebar.settings}
-              <span
+              <button
+                type="button"
+                onClick={onSettings}
+                title={t.sidebar.settingsTitle}
                 style={{
-                  marginLeft: 'auto',
-                  font: "500 10px 'JetBrains Mono', ui-monospace",
-                  color: 'var(--ink-4)',
+                  appearance: 'none',
+                  border: 0,
+                  background: 'transparent',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 9,
+                  padding: '7px 9px',
+                  borderRadius: 6,
+                  cursor: 'default',
+                  font: "500 13px 'Inter', ui-sans-serif",
+                  color: 'var(--ink-3)',
+                  textAlign: 'left',
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.background = 'var(--paper-deep)'
+                  e.currentTarget.style.color = 'var(--ink)'
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.background = 'transparent'
+                  e.currentTarget.style.color = 'var(--ink-3)'
                 }}
               >
-                ⌘,
-              </span>
-            </button>
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  style={{ flexShrink: 0 }}
+                >
+                  <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.38a2 2 0 0 0-.73-2.73l-.15-.1a2 2 0 0 1-1-1.72v-.51a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+                  <circle cx="12" cy="12" r="3" />
+                </svg>
+                {t.sidebar.settings}
+              </button>
+              <button
+                type="button"
+                onClick={onAbout}
+                title={t.sidebar.aboutTitle}
+                style={{ ...iconBtn, width: 32, height: 32, flexShrink: 0 }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.background = 'var(--paper-deep)'
+                  e.currentTarget.style.color = 'var(--ink)'
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.background = 'transparent'
+                  e.currentTarget.style.color = 'var(--ink-3)'
+                }}
+              >
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  style={{ flexShrink: 0 }}
+                >
+                  <circle cx="12" cy="12" r="10" />
+                  <path d="M12 16v-4" />
+                  <path d="M12 8h.01" />
+                </svg>
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -15,6 +15,7 @@ interface Props {
   onReview: () => void
   onRelationTypes: () => void
   onShortcuts: () => void
+  onAbout: () => void
 }
 
 export function TopBar({
@@ -24,6 +25,7 @@ export function TopBar({
   onReview,
   onRelationTypes,
   onShortcuts,
+  onAbout,
 }: Props) {
   const t = useT()
   const { graphList, currentGraphId, nodes } = useGraphStore()
@@ -160,7 +162,7 @@ export function TopBar({
             </span>
           )}
         </button>
-        <GraphIO onRelationTypes={onRelationTypes} onShortcuts={onShortcuts} />
+        <GraphIO onRelationTypes={onRelationTypes} onShortcuts={onShortcuts} onAbout={onAbout} />
       </div>
     </div>
   )

--- a/src/data/appInfo.ts
+++ b/src/data/appInfo.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+import { isDesktop } from '@/lib/isDesktop'
+
+export const APP_VERSION = __APP_VERSION__
+
+export const REPO_URL = 'https://github.com/nesso-how/nesso'
+export const WEBSITE_URL = 'https://nesso.how'
+export const DOCS_URL = 'https://nesso.how/docs/introduction'
+export const CHANGELOG_URL = `${REPO_URL}/blob/main/CHANGELOG.md`
+export const LICENSE_URL = `${REPO_URL}/blob/main/LICENSE`
+
+/** Opens a URL in the system browser on desktop; `window.open` on web. */
+export async function openExternal(url: string): Promise<void> {
+  if (isDesktop()) {
+    const { openUrl } = await import('@tauri-apps/plugin-opener')
+    await openUrl(url).catch(() => {})
+  } else {
+    window.open(url, '_blank', 'noopener,noreferrer')
+  }
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -145,6 +145,8 @@ const en = {
     newGraph: 'New',
     display: 'Display',
     settings: 'Settings',
+    about: 'About',
+    aboutTitle: 'About Nesso',
     untitled: 'Untitled',
     collapseSidebar: 'Collapse sidebar',
     websiteLinkTitle: 'Visit nesso.how',
@@ -191,6 +193,7 @@ const en = {
       close: 'Close dialog / deselect',
       search: 'Search concepts',
       addConcept: 'Add concept at viewport centre',
+      fit: 'Center / fit graph',
       review: 'Start spaced-repetition review',
       delete: 'Delete selected concept or relation',
       moveConcept: 'Nudge selected concept',
@@ -209,6 +212,7 @@ const en = {
     exportPng: 'Export graph (.png)',
     importGraph: 'Import graph',
     keyboardShortcuts: 'Keyboard shortcuts',
+    about: 'About Nesso',
   },
   bottomDock: {
     addConcept: '+ concept',
@@ -310,6 +314,18 @@ const en = {
     relationKinds: (n: number) => `${n} relation kinds`,
     filteredKinds: (n: number, total: number) => `${n} of ${total} kinds`,
     docsLink: 'Full reference',
+  },
+  about: {
+    title: 'About Nesso',
+    tagline: 'Typed knowledge graphs for active learning.',
+    version: (v: string) => `v${v}`,
+    links: {
+      github: 'GitHub',
+      website: 'Website',
+      documentation: 'Documentation',
+      changelog: 'Changelog',
+      license: 'License (MIT)',
+    },
   },
   mentor: {
     name: 'Socrates',

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -145,6 +145,8 @@ const it: typeof en = {
     newGraph: 'Nuovo',
     display: 'Visualizzazione',
     settings: 'Impostazioni',
+    about: 'Informazioni',
+    aboutTitle: 'Informazioni su Nesso',
     untitled: 'Senza titolo',
     collapseSidebar: 'Comprimi pannello laterale',
     websiteLinkTitle: 'Visita nesso.how',
@@ -191,6 +193,7 @@ const it: typeof en = {
       close: 'Chiudi finestra / deseleziona',
       search: 'Cerca concetti',
       addConcept: 'Aggiungi concetto al centro del viewport',
+      fit: 'Centra / adatta il grafo',
       review: 'Avvia revisione a ripetizione spaziata',
       delete: 'Elimina concetto o relazione selezionati',
       moveConcept: 'Sposta concetto selezionato',
@@ -209,6 +212,7 @@ const it: typeof en = {
     exportPng: 'Esporta grafo (png)',
     importGraph: 'Importa grafo',
     keyboardShortcuts: 'Scorciatoie da tastiera',
+    about: 'Informazioni su Nesso',
   },
   bottomDock: {
     addConcept: '+ concetto',
@@ -310,6 +314,18 @@ const it: typeof en = {
     relationKinds: (n) => `${n} tipi di relazione`,
     filteredKinds: (n, total) => `${n} di ${total} tipi`,
     docsLink: 'Riferimento completo',
+  },
+  about: {
+    title: 'Informazioni su Nesso',
+    tagline: "Grafi di conoscenza tipizzati per l'apprendimento attivo.",
+    version: (v) => `v${v}`,
+    links: {
+      github: 'GitHub',
+      website: 'Sito web',
+      documentation: 'Documentazione',
+      changelog: 'Changelog',
+      license: 'Licenza (MIT)',
+    },
   },
   mentor: {
     name: 'Socrate',

--- a/src/index.css
+++ b/src/index.css
@@ -34,6 +34,8 @@
   --accent: #6e2730;
   --shadow-md: 0 8px 28px -10px rgba(26, 24, 20, 0.18), 0 2px 8px rgba(26, 24, 20, 0.06);
   --shadow-lg: 0 28px 60px -16px rgba(26, 24, 20, 0.22), 0 8px 20px -8px rgba(26, 24, 20, 0.1);
+  --drop-shadow-lg: drop-shadow(0 28px 60px rgba(26, 24, 20, 0.22))
+    drop-shadow(0 8px 20px rgba(26, 24, 20, 0.1));
 }
 
 [data-theme='dark'] {
@@ -63,6 +65,8 @@
 
   --shadow-md: 0 8px 28px -10px rgba(0, 0, 0, 0.55), 0 2px 8px rgba(0, 0, 0, 0.4);
   --shadow-lg: 0 28px 60px -16px rgba(0, 0, 0, 0.7), 0 8px 20px -8px rgba(0, 0, 0, 0.5);
+  --drop-shadow-lg: drop-shadow(0 28px 60px rgba(0, 0, 0, 0.7))
+    drop-shadow(0 8px 20px rgba(0, 0, 0, 0.5));
 }
 
 *,

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -27,3 +27,5 @@ declare module '*.css' {
   const content: Record<string, string>
   export default content
 }
+
+declare const __APP_VERSION__: string

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,19 @@
 // SPDX-License-Identifier: MIT
+import { readFileSync } from 'node:fs'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { fileURLToPath, URL } from 'node:url'
 
 const host = process.env.TAURI_DEV_HOST
 
+const pkg = JSON.parse(
+  readFileSync(fileURLToPath(new URL('./package.json', import.meta.url)), 'utf-8'),
+) as { version: string }
+
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   plugins: [react()],
   clearScreen: false,
   resolve: {


### PR DESCRIPTION
Closes #17

## Summary

Adds a branded About dialog that surfaces app version, tagline, and external links (GitHub, website, documentation, changelog, license). Provides a desktop-style About entry point separate from Settings, as described in #17.

Version is injected at build time from `package.json` via Vite `define` (`__APP_VERSION__`), keeping web and desktop in sync without a runtime version fetch.

## Changes

- Add `AboutDialog` and `src/data/appInfo.ts` for shared metadata and links
- Inject `__APP_VERSION__` in `vite.config.ts`; declare in `vite-env.d.ts`
- Tauri: custom native menu with **About Nesso** (macOS app menu; Help submenu on Windows/Linux); emit `menu:about` to the webview
- Wire entry points through `App`, `TopBar`, `Sidebar`, and `GraphIO` (native menu, sidebar info button, ⋯ menu)
- Add en/it `about` strings; add **fit** shortcut label in `ShortcutsDialog`
- Sidebar footer: separate settings and About info controls
- Add `--drop-shadow-lg` CSS variable (light/dark themes)
- Update `CHANGELOG.md` `[Unreleased]` and `.cursor/rules/components.mdc`

## Checklist

- [x] Branch name follows the naming convention
- [x] `## [Unreleased]` in `CHANGELOG.md` updated

## Testing

- [x] Desktop: open **About Nesso** from macOS app menu / Windows–Linux Help menu; dialog shows version and links
- [x] Web: open About from sidebar info button and from ⋯ menu (sidebar collapsed)
- [x] Verify external links open in the browser
- [x] Toggle light/dark theme — dialog styling and drop shadow remain correct