### PR TITLE
fix(desktop): capitalize app display name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 ### Fixed
 
 - **Graphs:** Edits made within the autosave debounce window are no longer lost when switching graphs — `loadGraph` flushes the pending save first. A save still in flight during a switch can no longer leak the previous graph's saved-state fingerprint onto the newly loaded one (which faked or masked external-file conflicts).
+- **Desktop:** The app's display name is now capitalized (`Nesso`) — `productName` was lowercase, so the menu bar, Dock and `.app` bundle showed `nesso`. The window title was already `Nesso`.
 - **Desktop sync:** External edits to a graph file that don't bump its embedded `updatedAt` (e.g. hand edits in a text editor) are now detected via content comparison instead of being silently overwritten on the next in-app save. The conflict check also re-reads the live store right before deciding, closing a window where edits made during the reconcile could be reloaded over.
 - **Canvas:** Escape while renaming a concept on the canvas now cancels the edit (it used to commit, unlike the inspector). Releasing a new connection over an edge no longer creates an invisible ghost edge (only nodes are valid drop targets). Node/edge ids are now collision-checked on create and paste. Deleting a mixed selection removes explicitly selected edges too.
 - **Shortcuts:** Editing shortcuts (Backspace/Delete, ⌘C/V/Z, Enter, n, f, r) are disabled while any dialog is open — Backspace during a review no longer deletes the canvas selection underneath.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
-  "productName": "nesso",
+  "productName": "Nesso",
   "version": "0.1.0-alpha.28",
   "identifier": "dev.nesso.desktop",
   "build": {


### PR DESCRIPTION
## Summary

The macOS app shows its name in lowercase (`nesso`) next to the icon — in the menu bar, the Dock and the `.app` bundle. This is because the Tauri `productName` was set to `"nesso"`, while the window `title` was already `"Nesso"`. This PR makes the display name consistent.

## Changes

- `src-tauri/tauri.conf.json`: set `productName` from `"nesso"` to `"Nesso"`.
- `CHANGELOG.md`: added an entry under `[Unreleased] › Fixed`.

## Checklist

- [x] Branch name follows the naming convention
- [x] `## [Unreleased]` in `CHANGELOG.md` updated

## Testing

- Inspected `src-tauri/tauri.conf.json` to confirm `productName` was the lowercase source of the displayed name (the window `title` was already `Nesso`).
- Verified the release pipeline relies on `tauri-action`, which derives bundle filenames and the updater `latest.json` from `productName` — no hardcoded `nesso.app` / `nesso_*.dmg` references in CI or scripts to update.
- The `identifier` (`dev.nesso.desktop`) is unchanged, so saved data and auto-update stay compatible. The new name is visible after a desktop rebuild (`pnpm tauri build` or the release CI); the currently installed binary keeps showing `nesso` until rebuilt.