### PR TITLE
chore(release): add release.mjs prep script and drive the skill from it

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,78 +1,78 @@
 ---
 name: release
-description: Cut a new Nesso release — bump the synced version across all package.json files, tauri.conf.json, and the Tauri Rust crate (Cargo.toml/Cargo.lock), roll the CHANGELOG [Unreleased] section into a dated version with updated link refs, then tag and push to trigger the publish workflow. Use when the user asks to cut, ship, publish, or version-bump a release.
+description: Cut a new Nesso release — run scripts/release.mjs to bump the synced version across all package.json files, tauri.conf.json, and the Tauri Rust crate (Cargo.toml/Cargo.lock), roll the CHANGELOG [Unreleased] section into a dated version, refresh the lockfile and verify, then commit, tag, and push to trigger the publish workflow. Use when the user asks to cut, ship, publish, or version-bump a release.
 disable-model-invocation: true
 ---
 
 # Cut a release
 
-Step-by-step procedure for releasing Nesso. Pushing the `v*` tag triggers [`.github/workflows/release.yml`](../../../.github/workflows/release.yml): npm publish of the workspace packages (Trusted Publishing / OIDC), a signed universal macOS `.dmg` desktop build, and a GitHub Release. **The tag push is the point of no return — it publishes to the public. Confirm with the user before step 5.**
+`scripts/release.mjs` (`pnpm release`) does the deterministic prep — the version bump across all nine files, the CHANGELOG roll, the lockfile refresh, and `build`/`lint`/`format:check`. This skill **drives that script and supervises it**: it owns the judgment the script can't make (which version, what ships, when to publish) and closes the gaps the script deliberately leaves open (the git push, branch protection, worktrees).
+
+Pushing the `v*` tag triggers [`.github/workflows/release.yml`](../../../.github/workflows/release.yml): npm publish of the workspace packages (Trusted Publishing / OIDC), a signed universal macOS `.dmg` desktop build, and a GitHub Release. **The tag push is the point of no return — it publishes to the public. Confirm with the user before step 4.**
 
 For the conventions and the desktop auto-update / minisign signing details, see [`.rules/changelog.md`](../../../.rules/changelog.md); this skill executes that flow, it does not restate it.
 
 ## 0. Preconditions
 
-- Clean working tree, on an up-to-date `main` (or the release branch the user names).
-- `## [Unreleased]` in `CHANGELOG.md` already holds this release's notes — contributors fill it per PR (see CONTRIBUTING.md step 3). If it's empty, ask the user what's shipping before proceeding.
-- Per AGENTS.md → Git: never commit, tag, or push without the user's explicit go-ahead. Invoking `/release` covers the prep; step 5 needs its own confirmation.
+- Clean working tree, on an up-to-date `main` (or the release branch the user names). The script warns on a dirty tree and refuses `--commit` unless it's clean.
+- `## [Unreleased]` in `CHANGELOG.md` already holds this release's notes — contributors fill it per PR (see CONTRIBUTING.md step 3). The script stops if it's empty; if so, ask the user what's shipping before continuing.
+- Per AGENTS.md → Git: never commit, tag, or push without the user's explicit go-ahead. Invoking `/release` covers the prep; the push (step 4) needs its own confirmation.
 
 ## 1. Choose the version
 
 - `PREV` = the current version in root `package.json` (e.g. `0.1.0-alpha.28`).
-- Default `NEW` = increment the alpha counter (`…-alpha.N` → `…-alpha.N+1`). For a different bump (e.g. leaving alpha), confirm the target semver with the user.
+- Default `NEW` = increment the alpha counter (`…-alpha.N` → `…-alpha.N+1`). This is the script's default — no argument needed. For any other bump (e.g. leaving alpha), confirm the target semver with the user and pass it explicitly: `pnpm release 0.2.0`.
 - The tag will be `vNEW`.
 
-## 2. Bump the version everywhere — all nine must stay in sync
+## 2. Run the prep script
 
-Set the `version` field to `NEW` in every one of these (they are all currently identical; CI fails otherwise):
-
-- `package.json` (root)
-- `packages/formats/package.json`
-- `packages/graph/package.json`
-- `packages/mcp/package.json`
-- `packages/relation-types/package.json`
-- `packages/types/package.json`
-- `src-tauri/tauri.conf.json`
-- `src-tauri/Cargo.toml` — the `[package]` `version`
-- `src-tauri/Cargo.lock` — the `name = "nesso"` entry's `version` (mirrors `Cargo.toml`; **not** refreshed by `pnpm install`, so edit it by hand or it drifts and the desktop build's frozen-lockfile check fails)
-
-Inter-package deps use `workspace:*`; pnpm rewrites them to the real version at publish time, so there are no dependency ranges to edit by hand.
-
-Sanity check after editing — every occurrence should now be `NEW`, none left on `PREV`:
+Preview first when unsure, then run for real:
 
 ```bash
-grep -rn 'PREV' package.json packages/*/package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock
+pnpm release --dry-run     # print what would change, write nothing
+pnpm release [NEW]         # bump + roll changelog + pnpm install + build/lint/format, then STOP
 ```
 
-## 3. Roll the CHANGELOG
+What the script does:
 
-In `CHANGELOG.md`:
+- Bumps `version` to `NEW` in all **nine** synced files — the six `package.json`s, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock` (the `name = "nesso"` entry; `pnpm install` does **not** refresh it). It aborts on version **drift** — any file not already at `PREV` — so a forgotten file fails loudly instead of shipping out of sync.
+- Rolls `CHANGELOG.md`: moves `## [Unreleased]` into `## [NEW] - YYYY-MM-DD`, leaves a fresh empty `[Unreleased]`, and updates the two link references (URL derived from the existing `[Unreleased]` ref).
+- Runs `pnpm install`, `pnpm build`, `pnpm lint`, `pnpm format:check`.
 
-- Move everything under `## [Unreleased]` into a new `## [NEW] - YYYY-MM-DD` section (today's date), and leave a fresh **empty** `## [Unreleased]` at the top.
-- Update the link references at the bottom:
-  - change `[Unreleased]: …/compare/vPREV...HEAD` → `[Unreleased]: …/compare/vNEW...HEAD`
-  - add `[NEW]: https://github.com/nesso-how/nesso/compare/vPREV...vNEW`
-- The `## [NEW]` heading must match `src-tauri/tauri.conf.json`'s `version` **exactly** — `release.yml` extracts the GitHub Release body from the section whose heading matches that version. A mismatch ships an empty/placeholder release body.
+It then stops before any git mutation and prints the commit/tag/push commands. Flags: `--no-verify` (skip the build/lint pass), `--yes` (don't prompt on warnings), `--commit` (see step 3).
 
-## 4. Refresh the lockfile and verify
+**Supervise — close the gaps:**
 
-- Run `pnpm install` so `pnpm-lock.yaml` picks up the new workspace versions. CI runs `--frozen-lockfile`, so a stale lockfile fails the release.
-- Run `pnpm build`, `pnpm lint`, `pnpm format:check` — fix or report any failure before continuing.
-- Re-check: all nine versions equal `NEW`; the `## [NEW]` heading, the two link refs, and `tauri.conf.json` agree.
+- If the script aborts (drift, empty `[Unreleased]`, a failing build/lint), fix the **root cause** and re-run; don't hand-edit around it.
+- The list of version files lives in `JSON_VERSION_FILES` / `CARGO_VERSION_FILES` in the script. If a published package is added or removed, update the script **and** the list above so they stay the single source of truth.
+- The `## [NEW]` heading must match `tauri.conf.json`'s `version` exactly — `release.yml` extracts the GitHub Release body from the section with that heading, so a mismatch ships an empty release body. The script keeps them aligned; re-check after any manual fixup.
 
-## 5. Commit, tag, push — only after explicit confirmation
+## 3. (optional) Let the script commit and tag
 
-This publishes. Confirm with the user, then:
+Once prep is green and the user has confirmed, the script can create the commit + tag locally (it **never** pushes):
 
 ```bash
-git add -A
-git commit -m "chore(release): vNEW"
-git tag vNEW
-git push origin <branch>
-git push origin vNEW   # this tag push is what triggers release.yml
+pnpm release [NEW] --commit
 ```
 
-## 6. After the workflow
+Equivalently, run the `git add`/`commit`/`tag` commands it printed. Either way the commit message is `chore(release): vNEW` and the tag is `vNEW`.
 
-- Watch the run (`gh run watch`, or the Actions tab). It publishes the npm packages, builds the universal macOS `.dmg`, and creates the GitHub Release plus the signed `latest.json` consumed by the desktop auto-updater.
+## 4. Push — the point of no return, only after explicit confirmation
+
+This publishes. Confirm with the user, then push the release commit to `main` and the tag:
+
+```bash
+git push origin HEAD:main      # the release commit — a fast-forward of main
+git push origin vNEW           # the tag push is what triggers release.yml and publishes
+```
+
+Gap-closing notes from past releases:
+
+- **Branch protection:** `main` requires PRs + a passing status check, but a maintainer with bypass can push the release commit directly. This is a fast-forward, so it needs **no** `--force` — if a tool suggests forcing, it's wrong; plain `git push origin HEAD:main` succeeds and the remote reports `Bypassed rule violations`.
+- **Worktrees:** when releasing from a git worktree, push the worktree's own `HEAD` (`git push origin HEAD:main`). Do **not** `cd` into the main checkout to push — there `HEAD` points at a different commit and the push is a silent no-op (`Everything up-to-date`).
+
+## 5. After the workflow
+
+- Watch the run (`gh run watch <id> --exit-status`, or the Actions tab). It publishes the npm packages, builds the universal macOS `.dmg`, and creates the GitHub Release plus the signed `latest.json` consumed by the desktop auto-updater.
+- The npm job finishes in under a minute; the desktop `.dmg` build is the long pole (~10 min). **`publish-npm` succeeding does not mean the release is done** — and `gh run watch` can exit 0 on a transient API hiccup. Confirm `gh run view <id>` shows `completed / success` **and** `gh release view vNEW` resolves (with the `.dmg` + `latest.json` assets) before reporting success.
 - Confirm the GitHub Release body picked up the `## [NEW]` changelog section, and that `releases/latest/download/latest.json` resolves to this build.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "lint-staged": "lint-staged",
+    "release": "node scripts/release.mjs",
     "build:relation-types": "pnpm --filter @nesso-how/relation-types build",
     "build:types": "pnpm --filter @nesso-how/types build",
     "build:formats": "pnpm --filter @nesso-how/formats build",

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,226 @@
+/**
+ * Cut a Nesso release: bump the synced version across all nine version files,
+ * roll CHANGELOG [Unreleased] into a dated section, refresh the lockfile, and verify.
+ * Stops before publishing — the tag push (the irreversible, public step) stays manual.
+ *
+ * Usage:
+ *   node scripts/release.mjs [version] [--commit] [--no-verify] [--dry-run] [--yes]
+ *
+ *   version      explicit NEW version (e.g. 0.1.0-alpha.30, 0.2.0). Default: bump the -alpha.N counter.
+ *   --commit     also create the release commit and tag locally (never pushes).
+ *   --no-verify  skip pnpm install / build / lint / format:check.
+ *   --dry-run    print what would change; write nothing.
+ *   --yes        don't prompt on warnings (empty [Unreleased], not on main).
+ */
+
+import { readFile, writeFile } from 'node:fs/promises'
+import { execSync } from 'node:child_process'
+import { createInterface } from 'node:readline/promises'
+import { stdin, stdout } from 'node:process'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)))
+
+/** Files whose top-level JSON `version` is the synced release version. */
+const JSON_VERSION_FILES = [
+  'package.json',
+  'packages/formats/package.json',
+  'packages/graph/package.json',
+  'packages/mcp/package.json',
+  'packages/relation-types/package.json',
+  'packages/types/package.json',
+  'src-tauri/tauri.conf.json',
+]
+
+/** Rust crate files: Cargo.lock mirrors Cargo.toml and is not refreshed by `pnpm install`. */
+const CARGO_VERSION_FILES = ['src-tauri/Cargo.toml', 'src-tauri/Cargo.lock']
+
+/** @param {string} msg */
+function log(msg) {
+  console.log(msg)
+}
+
+/** @param {string} args @returns {string} */
+function git(args) {
+  return execSync(`git ${args}`, { cwd: ROOT, encoding: 'utf8' })
+}
+
+/** @param {string} cmd Streams output; throws (non-zero exit) to abort the release. */
+function run(cmd) {
+  log(`$ ${cmd}`)
+  execSync(cmd, { cwd: ROOT, stdio: 'inherit' })
+}
+
+/** @param {string} question @returns {Promise<boolean>} */
+async function confirm(question) {
+  const rl = createInterface({ input: stdin, output: stdout })
+  const answer = (await rl.question(`${question} [y/N] `)).trim().toLowerCase()
+  rl.close()
+  return answer === 'y' || answer === 'yes'
+}
+
+/** @param {string} prev @param {string | undefined} explicit @returns {string} */
+function nextVersion(prev, explicit) {
+  if (explicit) return explicit.replace(/^v/, '')
+  const m = prev.match(/^(.*-alpha\.)(\d+)$/)
+  if (!m) {
+    throw new Error(`cannot auto-increment "${prev}" (not -alpha.N); pass an explicit version`)
+  }
+  return `${m[1]}${Number(m[2]) + 1}`
+}
+
+/** @param {string} rel @param {string} content @returns {string | null} */
+function currentVersionOf(rel, content) {
+  if (rel.endsWith('.json')) return JSON.parse(content).version ?? null
+  const m = content.match(/name = "nesso"\nversion = "([^"]+)"/)
+  return m ? m[1] : null
+}
+
+/** @param {string} content @param {string} search @param {string} replacement @param {string} rel */
+function replaceOnce(content, search, replacement, rel) {
+  if (!content.includes(search)) throw new Error(`could not find version marker in ${rel}`)
+  return content.replace(search, replacement)
+}
+
+/** @param {string} changelog @returns {string} Body between ## [Unreleased] and the next ## [ heading. */
+function unreleasedBody(changelog) {
+  const start = changelog.indexOf('## [Unreleased]')
+  if (start === -1) throw new Error('no ## [Unreleased] heading in CHANGELOG.md')
+  const after = changelog.indexOf('\n', start) + 1
+  const nextHeading = changelog.indexOf('\n## [', after)
+  return changelog.slice(after, nextHeading === -1 ? changelog.length : nextHeading)
+}
+
+/** @param {string} changelog @param {string} prev @param {string} next @param {string} date @returns {string} */
+function rollChangelog(changelog, prev, next, date) {
+  const withSection = changelog.replace(
+    '## [Unreleased]\n\n',
+    `## [Unreleased]\n\n## [${next}] - ${date}\n\n`,
+  )
+  if (withSection === changelog) throw new Error('could not locate ## [Unreleased] block to roll')
+
+  const refMatch = withSection.match(/\[Unreleased\]: (\S+)\/compare\/v[\w.-]+\.\.\.HEAD/)
+  if (!refMatch) throw new Error('could not find [Unreleased] link reference')
+  const base = refMatch[1]
+
+  return withSection.replace(
+    refMatch[0],
+    `[Unreleased]: ${base}/compare/v${next}...HEAD\n[${next}]: ${base}/compare/v${prev}...v${next}`,
+  )
+}
+
+/** @param {string} next @param {boolean} committed */
+function printNextSteps(next, committed) {
+  log('')
+  log('Next — the publish step is irreversible, run it yourself:')
+  if (!committed) {
+    log('  git add -A')
+    log(`  git commit -m "chore(release): v${next}"`)
+    log(`  git tag v${next}`)
+  }
+  log('  git push origin HEAD:main')
+  log(`  git push origin v${next}   # pushing the tag triggers release.yml and publishes`)
+}
+
+async function main() {
+  const argv = process.argv.slice(2)
+  const flags = new Set(argv.filter((a) => a.startsWith('--')))
+  const positional = argv.filter((a) => !a.startsWith('--'))
+  const dryRun = flags.has('--dry-run')
+  const doCommit = flags.has('--commit')
+  const skipVerify = flags.has('--no-verify')
+  const assumeYes = flags.has('--yes')
+
+  const prev = JSON.parse(await readFile(join(ROOT, 'package.json'), 'utf8')).version
+  const next = nextVersion(prev, positional[0])
+  if (prev === next) throw new Error(`new version equals current (${prev})`)
+  log(`Releasing ${prev} -> ${next}${dryRun ? ' (dry run)' : ''}`)
+
+  const targets = [...JSON_VERSION_FILES, ...CARGO_VERSION_FILES]
+  const contents = new Map()
+  const drift = []
+  for (const rel of targets) {
+    const content = await readFile(join(ROOT, rel), 'utf8')
+    contents.set(rel, content)
+    const cur = currentVersionOf(rel, content)
+    if (cur !== prev) drift.push(`${rel}: ${cur}`)
+  }
+  if (drift.length) {
+    throw new Error(`version drift (expected ${prev}):\n  ${drift.join('\n  ')}`)
+  }
+
+  const dirty = git('status --porcelain').trim()
+  if (dirty && doCommit) {
+    throw new Error(`working tree not clean; --commit needs a clean base:\n${dirty}`)
+  }
+  if (dirty)
+    log('Warning: working tree has uncommitted changes; they will mix into the release diff.')
+
+  const branch = git('rev-parse --abbrev-ref HEAD').trim()
+  if (branch !== 'main' && !assumeYes && !dryRun) {
+    if (!(await confirm(`Not on main (on "${branch}"). Continue?`))) return
+  }
+
+  const changelog = await readFile(join(ROOT, 'CHANGELOG.md'), 'utf8')
+  if (!unreleasedBody(changelog).trim() && !assumeYes && !dryRun) {
+    if (!(await confirm('[Unreleased] is empty. Roll an empty release section anyway?'))) return
+  }
+
+  /** @type {Array<[string, string]>} */
+  const writes = []
+  for (const rel of JSON_VERSION_FILES) {
+    writes.push([
+      rel,
+      replaceOnce(contents.get(rel), `"version": "${prev}"`, `"version": "${next}"`, rel),
+    ])
+  }
+  for (const rel of CARGO_VERSION_FILES) {
+    writes.push([
+      rel,
+      replaceOnce(
+        contents.get(rel),
+        `name = "nesso"\nversion = "${prev}"`,
+        `name = "nesso"\nversion = "${next}"`,
+        rel,
+      ),
+    ])
+  }
+  const date = new Date().toISOString().slice(0, 10)
+  writes.push(['CHANGELOG.md', rollChangelog(changelog, prev, next, date)])
+
+  if (dryRun) {
+    log('Would update:')
+    for (const [rel] of writes) log(`  ${rel}`)
+    printNextSteps(next, false)
+    return
+  }
+
+  for (const [rel, content] of writes) await writeFile(join(ROOT, rel), content, 'utf8')
+  log(`Bumped ${writes.length} files; CHANGELOG rolled to [${next}] - ${date}.`)
+
+  if (!skipVerify) {
+    const fmt = writes.map(([rel]) => rel).filter((r) => r.endsWith('.json') || r.endsWith('.md'))
+    run(`pnpm exec prettier --write ${fmt.join(' ')}`)
+    run('pnpm install')
+    run('pnpm build')
+    run('pnpm lint')
+    run('pnpm format:check')
+  } else {
+    log('Skipped verification (--no-verify).')
+  }
+
+  if (doCommit) {
+    run('git add -A')
+    run(`git commit -m "chore(release): v${next}"`)
+    run(`git tag v${next}`)
+    log(`Committed and tagged v${next} (not pushed).`)
+  }
+
+  printNextSteps(next, doCommit)
+}
+
+main().catch((err) => {
+  console.error(`release: ${err.message}`)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Summary

Cutting v0.1.0-alpha.29 by hand surfaced that the documented procedure listed only **seven** version files while **nine** actually carry the version — the `/release` skill missed `src-tauri/Cargo.toml` and `src-tauri/Cargo.lock` (a gap that had bitten a prior release with a follow-up "sync Cargo.lock" commit). This PR codifies the mechanical release prep into a script so that drift can't recur, and rewires the `/release` skill to **drive and supervise** that script instead of restating the manual steps.

The version bump + CHANGELOG roll for alpha.29 already shipped on `main` via the release tag; this PR is the follow-up tooling only.

## Changes

- **`scripts/release.mjs` (new)** — `pnpm release` runs the deterministic prep: bumps `version` across all nine synced files (six `package.json`s, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`), rolls `CHANGELOG` `[Unreleased]` into a dated section with updated link refs, then runs `pnpm install` / `build` / `lint` / `format:check`. It **aborts on version drift** (any file not already at the previous version), stops before any git mutation, and prints the commit/tag/push commands. Flags: `--dry-run`, `--commit`, `--no-verify`, `--yes`.
- **`package.json`** — adds the `release` script (`node scripts/release.mjs`).
- **`.claude/skills/release/SKILL.md`** — collapses the old manual steps 2–4 into "run the script"; keeps the skill's judgment (version choice, changelog confirmation, the publish gate) and bakes in gap-closing notes learned this session: drift abort, worktree push (`git push origin HEAD:main`, not from the main checkout), branch-protection bypass (a fast-forward needs no `--force`), and "npm published ≠ release done".

## Checklist

- [x] Branch name follows the naming convention
- [ ] `## [Unreleased]` in `CHANGELOG.md` updated — N/A: internal release tooling, not user-facing.

## Testing

- `pnpm exec eslint scripts/release.mjs` — clean.
- `pnpm exec prettier --check scripts/release.mjs package.json .claude/skills/release/SKILL.md` — clean.
- `node scripts/release.mjs --dry-run` — correctly reports the 10 files it would touch (9 version files + `CHANGELOG`), computes the next version (`0.1.0-alpha.30`), warns on the dirty tree, and prints the publish commands without writing anything.
- The script mirrors the manual flow just executed for v0.1.0-alpha.29 (run concluded `success`; GitHub Release published with the universal `.dmg` and signed `latest.json`).