### PR TITLE
chore(ci): add rust job — rustfmt, clippy, cargo check/test for src-tauri

### DIFF
--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -17,7 +17,18 @@ pnpm run build                   # full app build
 pnpm run license-headers:check   # SPDX headers on src/** and src-tauri/src
 ```
 
+The `rust` CI job covers the native layer (`src-tauri/`). Run it too if the change touches `src-tauri/` (Rust, capabilities, `tauri.conf.json`); skip otherwise:
+
+```bash
+pnpm run icons:desktop                                            # generate gitignored icons that generate_context! embeds
+cargo fmt --all --check --manifest-path src-tauri/Cargo.toml      # rustfmt gate
+cargo clippy --all-targets --manifest-path src-tauri/Cargo.toml -- -D warnings
+cargo check --all-targets --manifest-path src-tauri/Cargo.toml
+cargo test --manifest-path src-tauri/Cargo.toml
+```
+
 - Run the steps individually so a failure is attributable to one step — don't `&&`-chain them into one opaque result.
 - Surface the first failure with its output and stop; do not push when anything is red.
-- `format:check` failures are usually fixed by `pnpm run format` — offer that. `lint` issues often by `pnpm run lint:fix`.
+- `format:check` failures are usually fixed by `pnpm run format` — offer that. `lint` issues often by `pnpm run lint:fix`; `cargo fmt --all --check` failures by `cargo fmt --all`.
+- `icons:desktop` is a prerequisite for the cargo steps: without the bundle icons, `tauri::generate_context!` fails to compile `lib.rs`. Locally they may already exist, but regenerate if unsure.
 - These mirror CI exactly; if `ci.yml` changes, update this list (see `.rules/maintenance.md`).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,71 @@ jobs:
       - run: pnpm run build:mcp
       - run: pnpm run build
       - run: pnpm run license-headers:check
+
+  # Native layer (src-tauri/). Runs in parallel with `check`; a red Rust gate
+  # blocks merge just like lint/build. See .github/workflows/release.yml for the
+  # macOS bundle build — this job is the per-PR fmt/lint/compile feedback loop.
+  rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust (stable) with rustfmt + clippy
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: ./src-tauri -> target
+
+      # Formatting needs neither the frontend nor system deps — run it first so a
+      # style-only failure fails fast before the heavier compile steps.
+      - run: cargo fmt --all --check
+        working-directory: src-tauri
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+
+      - name: Enable pnpm via Corepack
+        run: corepack enable
+
+      - name: Pnpm store path
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+
+      - run: pnpm install --frozen-lockfile
+
+      # `tauri::generate_context!` embeds the bundle icons listed in
+      # tauri.conf.json; they are gitignored and generated from the tile SVG, so
+      # without this step clippy/check/test fail to compile lib.rs. The frontend
+      # `dist/` is not needed for `cargo check`.
+      - name: Generate desktop icons from tile SVG
+        run: pnpm run icons:desktop
+
+      - name: Install Tauri Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            librsvg2-dev \
+            libayatana-appindicator3-dev
+
+      - run: cargo clippy --all-targets -- -D warnings
+        working-directory: src-tauri
+
+      - run: cargo check --all-targets
+        working-directory: src-tauri
+
+      - run: cargo test
+        working-directory: src-tauri

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,9 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  check:
+  # Web/JS lane: everything driven by pnpm — app + packages + MCP + docs build,
+  # format, lint, license headers. Paired with the `rust` job (cargo lane).
+  js:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -46,7 +48,7 @@ jobs:
       - run: pnpm run build
       - run: pnpm run license-headers:check
 
-  # Native layer (src-tauri/). Runs in parallel with `check`; a red Rust gate
+  # Native layer (src-tauri/). Runs in parallel with `js`; a red Rust gate
   # blocks merge just like lint/build. See .github/workflows/release.yml for the
   # macOS bundle build — this job is the per-PR fmt/lint/compile feedback loop.
   rust:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Added
+
+- **CI:** A dedicated `rust` job now gates the native Tauri layer (`src-tauri/`) on every PR, in parallel with the existing `check` job: `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo check --all-targets`, and `cargo test`. It installs the stable toolchain (rustfmt + clippy), caches `~/.cargo`/`target` via `swatinem/rust-cache`, installs the Tauri Linux system deps, and generates the gitignored bundle icons first (`tauri::generate_context!` embeds them). Previously the Rust side was invisible to CI and only failed at desktop-build/release time. The `preflight` skill mirrors the new steps for local parity.
+
 ## [0.1.0-alpha.29] - 2026-06-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Added
 
-- **CI:** A dedicated `rust` job now gates the native Tauri layer (`src-tauri/`) on every PR, in parallel with the existing `check` job: `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo check --all-targets`, and `cargo test`. It installs the stable toolchain (rustfmt + clippy), caches `~/.cargo`/`target` via `swatinem/rust-cache`, installs the Tauri Linux system deps, and generates the gitignored bundle icons first (`tauri::generate_context!` embeds them). Previously the Rust side was invisible to CI and only failed at desktop-build/release time. The `preflight` skill mirrors the new steps for local parity.
+- **CI:** A dedicated `rust` job now gates the native Tauri layer (`src-tauri/`) on every PR, in parallel with the renamed `js` job (was `check`): `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo check --all-targets`, and `cargo test`. It installs the stable toolchain (rustfmt + clippy), caches `~/.cargo`/`target` via `swatinem/rust-cache`, installs the Tauri Linux system deps, and generates the gitignored bundle icons first (`tauri::generate_context!` embeds them). Previously the Rust side was invisible to CI and only failed at desktop-build/release time. The `preflight` skill mirrors the new steps for local parity.
 
 ## [0.1.0-alpha.29] - 2026-06-12
 

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: MIT
 fn main() {
-  tauri_build::build()
+    tauri_build::build()
 }


### PR DESCRIPTION
## Summary

CI (`.github/workflows/ci.yml`) never touched `src-tauri/` — no `rustfmt`, no `clippy`, no `cargo check`, no `cargo test`. The entire native Tauri layer (`lib.rs`, IPC commands, capabilities, `tauri.conf.json`) was invisible to the automated loop: a change that broke the Rust side went green as long as the TypeScript built, and only failed at `pnpm build:desktop` / release time. For an AI-assisted workflow that is a blind spot as large as the missing frontend tests.

This adds a dedicated **`rust` job** that runs in parallel with the `js` job (the pnpm/JS lane, renamed from `check` for naming parity) and gates fmt + lint + compile + test on every PR. A red Rust job blocks merge just like lint/build.

Closes #30

## Changes

- **`rust` CI job** in `ci.yml`: `cargo fmt --all --check` (first, so style-only failures fail fast before the heavy compile), `cargo clippy --all-targets -- -D warnings`, `cargo check --all-targets`, `cargo test`.
- Stable toolchain via `dtolnay/rust-toolchain@stable` with `rustfmt` + `clippy`; `swatinem/rust-cache@v2` for `~/.cargo` + `target` (same `workspaces: ./src-tauri -> target` as `release.yml`); Tauri Linux system deps (`libwebkit2gtk-4.1-dev`, `libgtk-3-dev`, `librsvg2-dev`, `libayatana-appindicator3-dev`).
- Generate the gitignored bundle icons (`pnpm run icons:desktop`) before the cargo steps — `tauri::generate_context!` embeds the icons listed in `tauri.conf.json`, so without them `clippy`/`check`/`test` fail to compile `lib.rs`. The frontend `dist/` is not needed for `cargo check`, so it is not built.
- Reformat `src-tauri/build.rs` (2-space → rustfmt 4-space) so the new `cargo fmt --all --check` gate passes on existing code.
- Rename the existing pnpm/JS job `check` → `js` so both required status checks read on the same axis (`js` + `rust`) instead of mixing a generic action name with a technology name.
- Update the `preflight` skill with the Rust steps for local CI parity.

## Checklist

- [x] Branch name follows the naming convention
- [x] `## [Unreleased]` in `CHANGELOG.md` updated

## Testing

Ran the full job chain locally against the worktree (toolchain 1.88.0):

- `pnpm run icons:desktop` → icons generated.
- `cargo fmt --all --check` → clean (after reformatting `build.rs`).
- `cargo clippy --all-targets -- -D warnings` → no warnings.
- `cargo check --all-targets` → compiles.
- `cargo test` → 0 tests, passes (placeholder step to grow into).

Also confirmed `tauri::generate_context!` does **not** require the frontend `dist/` for `cargo check` (icons are the only prerequisite), validated the workflow YAML parses, and ran `prettier --check` on all changed files.

## Note for the reviewer

The issue also asks to mark the Rust checks as **required status checks**. Done: the repo ruleset `main protection` now requires `js` + `rust` (updated in lockstep with the job rename), so a red Rust job blocks merge.
