### PR TITLE
chore: add Vitest unit/integration tests + CI gate

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,6 @@
+---
+paths:
+  - '**/*.test.{ts,tsx}'
+---
+
+@../../.rules/testing.md

--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -1,0 +1,9 @@
+---
+description: Vitest unit/integration tests — layout, env split, resolution, CI gate
+globs: '**/*.test.{ts,tsx}'
+alwaysApply: false
+---
+
+Canonical content lives in [`.rules/testing.md`](../../.rules/testing.md). Edit that file, not this wrapper.
+
+@.rules/testing.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,10 @@ jobs:
 
       - run: pnpm run format:check
       - run: pnpm run lint
+      # Fast correctness signal: pure-logic unit/integration tests. `pnpm install`
+      # already ran `prepare`, so the workspace package `dist/` outputs the tests
+      # resolve against are present. This step gates the PR like the others.
+      - run: pnpm run test:coverage
       # `tsc -b` is not run on its own here: `pnpm run build` already runs it
       # (`… && tsc -b && vite build`), so a standalone step would type-check twice.
       - run: pnpm run build:mcp

--- a/.rules/maintenance.md
+++ b/.rules/maintenance.md
@@ -9,6 +9,7 @@ When you modify code in an area covered by a rule, update that rule's canonical 
 | `src/types/graph.ts`, `src/data/relationTypes.ts`           | [`.rules/graph-model.md`](graph-model.md)                       |
 | `src/components/mentor/MentorBubble.tsx`, AI provider/model | [`.rules/mentor.md`](mentor.md)                                 |
 | Coding patterns, naming, import conventions                 | [`.rules/conventions.md`](conventions.md)                       |
+| `*.test.ts`, `vitest.config.ts`, test scripts, CI test gate | [`.rules/testing.md`](testing.md)                               |
 | `CHANGELOG.md`                                              | [`.rules/changelog.md`](changelog.md)                           |
 | Architectural constraints, "never do X" rules               | `AGENTS.md` → **Constraints**                                   |
 | Overall stack, layout, core concepts                        | `AGENTS.md` → **Stack** / **Source layout** / **Core concepts** |

--- a/.rules/testing.md
+++ b/.rules/testing.md
@@ -1,0 +1,58 @@
+# Testing
+
+Unit/integration tests run on **Vitest**. They cover pure, side-effect-free logic — the base of the pyramid. Browser/e2e flows are a separate concern (issue #28), so this layer never touches Tauri, the network, or real rendering.
+
+## When to add tests
+
+When a change adds or alters logic this layer can reach, extend the co-located tests **in the same change**: pure functions (packages, `src/lib/**`), store mutations/selectors, and the workspace disk↔IDB layer. This is a judgement call, not a mandate to test everything — weigh it by regression risk:
+
+- **Default to a test** for branchy or stateful logic: validation, serialization, name/id dedup, merge/reconcile, undo/redo, collision handling.
+- **Usually skip** a one-obvious-path helper, a thin pass-through, or pure UI wiring.
+- **Out of scope here:** component rendering and real Tauri/network — those belong to e2e (#28).
+
+Regression-prone logic landing without a test should be the exception, and worth a line in the PR when it happens.
+
+## Layout and scripts
+
+- Co-locate `*.test.ts` next to the code under test (e.g. `packages/formats/src/index.test.ts`, `src/lib/workspace/paths.test.ts`).
+- Import the test API explicitly (`import { describe, expect, it } from 'vitest'`) — there is no `globals: true`, so no tsconfig `types` entry is needed.
+- Scripts: `pnpm test` (run once, CI), `pnpm test:watch` (watch), `pnpm test:coverage` (v8 coverage report).
+
+## Environment split
+
+Default environment is **`node`**. A file that touches the store, React, or the DOM opts into jsdom with a first-line docblock:
+
+```ts
+// @vitest-environment jsdom
+```
+
+Only the store-slice test needs jsdom today (the editing slice imports `@xyflow/react`). Everything else — package logic, geometry, ids, clipboard, workspace path/manifest helpers — stays in `node`.
+
+## Module resolution (`vitest.config.ts`)
+
+- `@/…` → `src/…`.
+- `@nesso-how/types` and `@nesso-how/relation-types` are aliased to their **source** (`packages/*/src/index.ts`) so tests run against source without a build.
+- `@nesso-how/graph` is **not** aliased: its barrel re-exports built `.js` paths and pulls in React, so it resolves to `dist`. That `dist` is always present because `prepare` rebuilds every workspace package on `pnpm install`. Import geometry/helpers from the specific source file (`./geometry.js`) in the package's own tests to avoid the barrel.
+
+## Keeping test files out of published packages
+
+Each package's `tsconfig.json` (`include: ["src"]`) also lists `"exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]`, so `pnpm --filter … build` never emits test files into `dist` (and `files: ["dist"]` never publishes them). Add the same exclude when giving a new package its first test.
+
+## Conventions
+
+- App-side test files live under `src/`, so they need the SPDX header like any other `src` file (license-headers gate).
+- Test pure functions and store mutations directly; for store slices, compose a headless vanilla store from the slice creators (`zustand/vanilla` `createStore`) instead of importing the persisted `useGraphStore`.
+- Reset module-level singletons (e.g. the graph clipboard via `setGraphClipboard(null)`, the disk-sync cache via `setDiskSyncCache(...)`) in `beforeEach`.
+
+## Workspace / IndexedDB integration
+
+The workspace layer (`src/lib/workspace/**`, `src/store/db.ts`) is the most regression-prone area, so test it as real integration rather than mocking each helper:
+
+- **IndexedDB** — `import 'fake-indexeddb/auto'` as the **first** import (before any module that loads `@/store/db`, which opens the DB at module scope). Clear it with `dbClearGraphs()` in `beforeEach`. `db.ts` and the store run unmodified against a real in-memory IDB.
+- **Tauri fs** — mock only at the boundary, reusing the shared in-memory filesystem in `src/test/fakeTauriFs.ts`: `vi.mock('@tauri-apps/plugin-fs', async () => (await import('@/test/fakeTauriFs')).fakeFsPlugin)` (and `…fakePathApi` / `…fakeCoreApi` / `…fakeDialogApi`). The static `import { tauriFsState }` and these dynamic imports resolve to the same instance, so assertions read the same disk the mocks mutate. Everything above the plugin (`sync`, `graphFiles`, `manifest`, `paths`) then exercises the real merge logic. `reset()` it in `beforeEach`. See `src/lib/workspace/sync.test.ts`.
+- **Store IO in web mode** — `isDesktop()` is false under jsdom, so graph-management mutations persist through IndexedDB only and need no fs mock. Seed `loadGraphList()` first so every `graphList` meta has a backing record.
+- **Store IO in desktop mode** — set `window.__TAURI_INTERNALS__ = {}` in `beforeEach` to flip `isDesktop()` true; the store then drives the real workspace layer against the fake fs + fake-indexeddb (disk is the source of truth). See `src/store/slices/graph-management.desktop.test.ts`.
+
+## CI
+
+`pnpm test:coverage` runs as a required step in `.github/workflows/ci.yml`, gating PRs alongside `format:check`, `lint`, and `build`. Package `dist` is in place because the prior `pnpm install --frozen-lockfile` step runs `prepare`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ Area-specific rules (canonical content in `.rules/`, auto-attached per file area
 | Semantic edge model — categories, relation types, encoding      | [`.rules/graph-model.md`](.rules/graph-model.md)     |
 | Zustand store shape, mutations, selector patterns               | [`.rules/store.md`](.rules/store.md)                 |
 | Socratic AI mentor — MentorBubble, system prompt, chat API      | [`.rules/mentor.md`](.rules/mentor.md)               |
+| Vitest tests — layout, env split, module resolution, CI gate    | [`.rules/testing.md`](.rules/testing.md)             |
 | `CHANGELOG.md` (Keep a Changelog), `[Unreleased]`, release flow | [`.rules/changelog.md`](.rules/changelog.md)         |
 | Keeping the `.rules/` files in sync with the codebase           | [`.rules/maintenance.md`](.rules/maintenance.md)     |
 | PR titles/bodies — match `.github/PULL_REQUEST_TEMPLATE.md`     | [`.rules/pull-requests.md`](.rules/pull-requests.md) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 ### Added
 
 - **CI:** A dedicated `rust` job now gates the native Tauri layer (`src-tauri/`) on every PR, in parallel with the renamed `js` job (was `check`): `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo check --all-targets`, and `cargo test`. It installs the stable toolchain (rustfmt + clippy), caches `~/.cargo`/`target` via `swatinem/rust-cache`, installs the Tauri Linux system deps, and generates the gitignored bundle icons first (`tauri::generate_context!` embeds them). Previously the Rust side was invisible to CI and only failed at desktop-build/release time. The `preflight` skill mirrors the new steps for local parity.
+- **Testing:** Introduced **Vitest** for fast, deterministic unit/integration tests on pure logic — the base of the testing pyramid (complements e2e, #28). Covers graph serialization (`@nesso-how/formats`), edge geometry and rating colors (`@nesso-how/graph`), FSRS/display types (`@nesso-how/types`), id generation, the canvas clipboard, the Zustand `graph-editing` and `graph-management` slices, and the regression-prone workspace disk↔IndexedDB layer (manifest, paths, file naming/dedup, two-phase sync) exercised as real integration against an in-memory Tauri-fs boundary plus `fake-indexeddb`. Added `test` / `test:watch` / `test:coverage` scripts and a required `test` step in CI that gates PRs. Test conventions live in `.rules/testing.md`.
 
 ## [0.1.0-alpha.29] - 2026-06-12
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "lint:fix": "eslint . --fix",
     "lint-staged": "lint-staged",
     "release": "node scripts/release.mjs",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "build:relation-types": "pnpm --filter @nesso-how/relation-types build",
     "build:types": "pnpm --filter @nesso-how/types build",
     "build:formats": "pnpm --filter @nesso-how/formats build",
@@ -60,18 +63,22 @@
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react": "^4.3.4",
+    "@vitest/coverage-v8": "^4.1.8",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.24",
+    "fake-indexeddb": "^6.2.5",
     "globals": "^16.5.0",
     "husky": "^9.1.7",
+    "jsdom": "^29.1.1",
     "lint-staged": "^17.0.7",
     "prettier": "^3.6.2",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.46.4",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^4.1.8"
   },
   "lint-staged": {
     "*.{ts,tsx,js,mjs,cjs}": [

--- a/packages/formats/src/index.test.ts
+++ b/packages/formats/src/index.test.ts
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+import type { Edge, Node } from '@xyflow/react'
+import type { ConceptNodeData } from '@nesso-how/types'
+import { defaultConceptReviewFields } from '@nesso-how/types'
+import { describe, expect, it } from 'vitest'
+import {
+  deserializeGraph,
+  nodesForGraphShareExport,
+  serializeGraph,
+  type NessoGraphFile,
+} from './index.js'
+
+function makeNode(id: string, data?: Partial<ConceptNodeData>): Node<ConceptNodeData> {
+  return {
+    id,
+    position: { x: 0, y: 0 },
+    data: { text: id, ...defaultConceptReviewFields(), ...data },
+  }
+}
+
+function makeEdge(id: string, source: string, target: string): Edge {
+  return { id, source, target, type: 'nesso', data: { type: 'causes' } }
+}
+
+describe('serializeGraph / deserializeGraph', () => {
+  it('round-trips a valid graph file', () => {
+    const file: NessoGraphFile = {
+      name: 'Demo',
+      nodes: [makeNode('n1'), makeNode('n2')],
+      edges: [makeEdge('e1', 'n1', 'n2')],
+    }
+    const parsed = deserializeGraph(serializeGraph(file))
+    expect(parsed.name).toBe('Demo')
+    expect(parsed.nodes.map((n) => n.id)).toEqual(['n1', 'n2'])
+    expect(parsed.edges).toEqual(file.edges)
+  })
+
+  it('produces pretty-printed JSON', () => {
+    const json = serializeGraph({ name: 'X', nodes: [], edges: [] })
+    expect(json).toContain('\n')
+    expect(JSON.parse(json)).toMatchObject({ name: 'X' })
+  })
+
+  it('normalizes partial node data with fresh review fields and a string text', () => {
+    const json = JSON.stringify({
+      name: 'Hand-written',
+      nodes: [{ id: 'n1', position: { x: 1, y: 2 }, data: { text: 'hi' } }],
+      edges: [],
+    })
+    const node = deserializeGraph(json).nodes[0]
+    expect(node.data).toMatchObject({ text: 'hi', ...defaultConceptReviewFields() })
+  })
+
+  it('coerces a non-string text to an empty string', () => {
+    const json = JSON.stringify({
+      name: 'X',
+      nodes: [{ id: 'n1', position: { x: 0, y: 0 }, data: { text: 42 } }],
+      edges: [],
+    })
+    expect(deserializeGraph(json).nodes[0].data.text).toBe('')
+  })
+})
+
+describe('deserializeGraph validation', () => {
+  it('rejects a file missing the nodes/edges arrays', () => {
+    expect(() => deserializeGraph('{}')).toThrow(/missing nodes or edges/)
+    expect(() => deserializeGraph(JSON.stringify({ nodes: [] }))).toThrow(/missing nodes or edges/)
+  })
+
+  it('rejects a node without a valid id or position', () => {
+    const noId = JSON.stringify({ nodes: [{ position: { x: 0, y: 0 } }], edges: [] })
+    expect(() => deserializeGraph(noId)).toThrow(/node 0 is missing a valid id or position/)
+
+    const nanPos = JSON.stringify({
+      nodes: [{ id: 'n1', position: { x: Number.NaN, y: 0 } }],
+      edges: [],
+    })
+    expect(() => deserializeGraph(nanPos)).toThrow(/node 0 is missing a valid id or position/)
+  })
+
+  it('rejects an edge missing id, source or target', () => {
+    const json = JSON.stringify({
+      nodes: [{ id: 'n1', position: { x: 0, y: 0 } }],
+      edges: [{ id: 'e1', source: 'n1' }],
+    })
+    expect(() => deserializeGraph(json)).toThrow(/edge 0 is missing id, source or target/)
+  })
+})
+
+describe('nodesForGraphShareExport', () => {
+  it('resets personal review history while keeping text and elaboration', () => {
+    const reviewed = makeNode('n1', {
+      stability: 99,
+      reps: 7,
+      lastRating: 4,
+      elaboration: { definition: 'd', examples: 'e', notes: 'n' },
+    })
+    const [stripped] = nodesForGraphShareExport([reviewed])
+    expect(stripped.data).toMatchObject({
+      text: 'n1',
+      ...defaultConceptReviewFields(),
+      elaboration: { definition: 'd', examples: 'e', notes: 'n' },
+    })
+    expect(stripped.data.stability).toBe(0)
+    expect(stripped.data.reps).toBe(0)
+    expect(stripped.data.lastRating).toBe(0)
+  })
+
+  it('omits the elaboration key when there is none', () => {
+    const [stripped] = nodesForGraphShareExport([makeNode('n1')])
+    expect('elaboration' in stripped.data).toBe(false)
+  })
+})

--- a/packages/formats/tsconfig.json
+++ b/packages/formats/tsconfig.json
@@ -9,5 +9,6 @@
     "declaration": true,
     "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/packages/graph/src/geometry.test.ts
+++ b/packages/graph/src/geometry.test.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+import { describe, expect, it } from 'vitest'
+import {
+  arcControlPoint,
+  defaultCurveFlip,
+  effectiveCurveFlip,
+  nessoArcPath,
+  nodeCenterX,
+  nodeCenterY,
+  rectExit,
+} from './geometry.js'
+
+describe('defaultCurveFlip', () => {
+  it('flips only when the target is above-right or below-left of the source', () => {
+    // target above and to the right -> above !== left -> flip
+    expect(defaultCurveFlip(0, 0, 10, -10)).toBe(true)
+    // target below and to the left -> flip
+    expect(defaultCurveFlip(0, 0, -10, 10)).toBe(true)
+    // target above and to the left -> no flip
+    expect(defaultCurveFlip(0, 0, -10, -10)).toBe(false)
+    // target below and to the right -> no flip
+    expect(defaultCurveFlip(0, 0, 10, 10)).toBe(false)
+  })
+})
+
+describe('nodeCenterX / nodeCenterY', () => {
+  it('uses measured dimensions when present', () => {
+    const node = { position: { x: 10, y: 20 }, measured: { width: 100, height: 40 } }
+    expect(nodeCenterX(node)).toBe(60)
+    expect(nodeCenterY(node)).toBe(40)
+  })
+
+  it('falls back to the default 80x32 box when unmeasured', () => {
+    expect(nodeCenterX({ position: { x: 0 } })).toBe(40)
+    expect(nodeCenterY({ position: { y: 0 } })).toBe(16)
+  })
+})
+
+describe('rectExit', () => {
+  it('returns the center when source and target coincide', () => {
+    expect(rectExit(5, 5, 10, 10, 5, 5)).toEqual({ x: 5, y: 5 })
+  })
+
+  it('exits through the right edge for a horizontal target', () => {
+    // half-width 10, pointing straight right -> x advances by 10
+    expect(rectExit(0, 0, 20, 20, 100, 0)).toEqual({ x: 10, y: 0 })
+  })
+
+  it('exits through the bottom edge for a vertical target', () => {
+    expect(rectExit(0, 0, 20, 20, 0, 100)).toEqual({ x: 0, y: 10 })
+  })
+})
+
+describe('arcControlPoint', () => {
+  it('bends perpendicular to the source->target line', () => {
+    const { cpx, cpy } = arcControlPoint(0, 0, 100, 0)
+    expect(cpx).toBe(50) // midpoint stays on the x axis
+    expect(cpy).toBeGreaterThan(0) // bows downward (perpendicular)
+  })
+
+  it('mirrors the bend when curveFlip is set', () => {
+    const a = arcControlPoint(0, 0, 100, 0, 0, false)
+    const b = arcControlPoint(0, 0, 100, 0, 0, true)
+    expect(b.cpy).toBeCloseTo(-a.cpy)
+  })
+})
+
+describe('nessoArcPath', () => {
+  it('draws a straight line and midpoint label when straight=true', () => {
+    const r = nessoArcPath(0, 0, 100, 50, 0, true)
+    expect(r.path).toBe('M 0 0 L 100 50')
+    expect(r.labelX).toBe(50)
+    expect(r.labelY).toBe(25)
+    expect(r.arrowAngle).toBeCloseTo(Math.atan2(50, 100))
+  })
+
+  it('draws a quadratic curve when straight=false', () => {
+    const r = nessoArcPath(0, 0, 100, 0)
+    expect(r.path).toMatch(/^M 0 0 Q /)
+    expect(r.path).toContain(' 100 0')
+  })
+})
+
+describe('effectiveCurveFlip', () => {
+  it('computes the automatic flip when auto and not pinned', () => {
+    expect(effectiveCurveFlip(true, false, false, 0, 0, 10, -10)).toBe(true)
+  })
+
+  it('honors the stored flip when pinned or not auto', () => {
+    expect(effectiveCurveFlip(true, true, true, 0, 0, 10, 10)).toBe(true)
+    expect(effectiveCurveFlip(false, false, false, 0, 0, 10, -10)).toBe(false)
+  })
+})

--- a/packages/graph/tsconfig.json
+++ b/packages/graph/tsconfig.json
@@ -10,5 +10,6 @@
     "skipLibCheck": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/packages/types/src/index.test.ts
+++ b/packages/types/src/index.test.ts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+import { describe, expect, it } from 'vitest'
+import {
+  defaultConceptReviewFields,
+  defaultGraphDisplay,
+  mergeGraphDisplay,
+  nodeToCard,
+  type ConceptNodeData,
+  type NessoSettings,
+} from './index.js'
+
+describe('defaultConceptReviewFields', () => {
+  it('returns zeroed FSRS fields for a fresh concept', () => {
+    expect(defaultConceptReviewFields()).toEqual({
+      stability: 0,
+      difficulty: 0,
+      reps: 0,
+      lapses: 0,
+      fsrsState: 0,
+      due: 0,
+      lastReview: 0,
+      lastRating: 0,
+      learningSteps: 0,
+    })
+  })
+
+  it('returns a fresh object each call (no shared mutable reference)', () => {
+    const a = defaultConceptReviewFields()
+    const b = defaultConceptReviewFields()
+    expect(a).not.toBe(b)
+  })
+})
+
+describe('defaultGraphDisplay', () => {
+  it('falls back to defaults when no settings are provided', () => {
+    expect(defaultGraphDisplay()).toEqual({
+      edgeEncoding: 'full',
+      showHeatmap: true,
+      curveStyle: 'arc',
+      autoCurveFlip: true,
+    })
+  })
+
+  it('reads values from the provided settings', () => {
+    expect(
+      defaultGraphDisplay({
+        edgeEncoding: 'minimal',
+        showHeatmap: false,
+        curveStyle: 'straight',
+        autoCurveFlip: false,
+      }),
+    ).toEqual({
+      edgeEncoding: 'minimal',
+      showHeatmap: false,
+      curveStyle: 'straight',
+      autoCurveFlip: false,
+    })
+  })
+})
+
+describe('mergeGraphDisplay', () => {
+  const settings = {
+    edgeEncoding: 'category',
+    showHeatmap: false,
+    curveStyle: 'straight',
+    autoCurveFlip: true,
+  } as NessoSettings
+
+  it('uses settings-derived defaults when nothing is stored', () => {
+    expect(mergeGraphDisplay(undefined, settings)).toEqual({
+      edgeEncoding: 'category',
+      showHeatmap: false,
+      curveStyle: 'straight',
+      autoCurveFlip: true,
+    })
+  })
+
+  it('lets a partial stored display override individual fields', () => {
+    expect(mergeGraphDisplay({ edgeEncoding: 'full' }, settings)).toMatchObject({
+      edgeEncoding: 'full',
+      showHeatmap: false,
+      curveStyle: 'straight',
+    })
+  })
+
+  it('preserves a stored autoCurveFlip of false rather than falling back to true', () => {
+    expect(mergeGraphDisplay({ autoCurveFlip: false }, settings).autoCurveFlip).toBe(false)
+  })
+})
+
+describe('nodeToCard', () => {
+  const base: ConceptNodeData = {
+    text: 'concept',
+    ...defaultConceptReviewFields(),
+  }
+
+  it('maps persisted fields onto a ts-fsrs Card', () => {
+    const card = nodeToCard({
+      ...base,
+      stability: 12,
+      difficulty: 5,
+      reps: 3,
+      lapses: 1,
+      fsrsState: 2,
+      due: 1_000,
+      lastReview: 500,
+      learningSteps: 2,
+    })
+    expect(card.stability).toBe(12)
+    expect(card.difficulty).toBe(5)
+    expect(card.reps).toBe(3)
+    expect(card.lapses).toBe(1)
+    expect(card.state).toBe(2)
+    expect(card.learning_steps).toBe(2)
+    expect(card.due).toEqual(new Date(1_000))
+    expect(card.last_review).toEqual(new Date(500))
+  })
+
+  it('treats due=0 as due-now and lastReview=0 as never reviewed', () => {
+    const card = nodeToCard(base)
+    expect(card.last_review).toBeUndefined()
+    expect(card.due).toBeInstanceOf(Date)
+  })
+
+  it('defaults learning_steps to 0 when the field is absent', () => {
+    const { learningSteps: _omit, ...withoutStep } = base
+    expect(nodeToCard(withoutStep).learning_steps).toBe(0)
+  })
+})

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -9,5 +9,6 @@
     "declaration": true,
     "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.7.0(vite@6.4.2(@types/node@24.13.1)(yaml@2.9.0))
+      '@vitest/coverage-v8':
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
       eslint:
         specifier: ^9.39.1
         version: 9.39.4
@@ -93,12 +96,18 @@ importers:
       eslint-plugin-react-refresh:
         specifier: ^0.4.24
         version: 0.4.26(eslint@9.39.4)
+      fake-indexeddb:
+        specifier: ^6.2.5
+        version: 6.2.5
       globals:
         specifier: ^16.5.0
         version: 16.5.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       lint-staged:
         specifier: ^17.0.7
         version: 17.0.7
@@ -114,6 +123,9 @@ importers:
       vite:
         specifier: ^6.3.5
         version: 6.4.2(@types/node@24.13.1)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@24.13.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@6.4.2(@types/node@24.13.1)(yaml@2.9.0))
 
   docs:
     dependencies:
@@ -238,6 +250,21 @@ importers:
         version: 5.8.3
 
 packages:
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@astrojs/compiler@4.0.0':
     resolution: {integrity: sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==}
@@ -385,6 +412,14 @@ packages:
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@capsizecss/unpack@4.0.0':
     resolution: {integrity: sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==}
     engines: {node: '>=18'}
@@ -399,6 +434,42 @@ packages:
   '@clack/prompts@1.5.1':
     resolution: {integrity: sha512-zccHj2z2oCCO4yrDiRSlFOxWerGqRiysP7a5jPK6uoI9URKAquwY42Dd/iUP8JWHxEzdRe4TlbvZCo8z1/mhrw==}
     engines: {node: '>= 20.12.0'}
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.3':
+    resolution: {integrity: sha512-DOgvIPkikIOixQRlD4YF31VN6fLLUTdrzhfRbis8vm0kMTgIbEPX0Ip/YX9fOeV9iywAS4sUUbTclpan7yYP8Q==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.5':
+    resolution: {integrity: sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@ctrl/tinycolor@4.2.0':
     resolution: {integrity: sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==}
@@ -756,6 +827,15 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@expressive-code/core@0.42.0':
     resolution: {integrity: sha512-MN11+9nfmaC7sYu2BZJXAXqwkBRt8t1xTSqP+Ti1NfTEskgl6xUnzDxoaiQkg0BMzpglA0pys4dpDKquP/cyIw==}
@@ -1169,6 +1249,9 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tauri-apps/api@2.11.0':
     resolution: {integrity: sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==}
 
@@ -1270,6 +1353,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/d3-color@3.1.3':
     resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
 
@@ -1290,6 +1376,9 @@ packages:
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -1418,6 +1507,44 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  '@vitest/coverage-v8@4.1.8':
+    resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
+    peerDependencies:
+      '@vitest/browser': 4.1.8
+      vitest: 4.1.8
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
+
   '@xyflow/react@12.10.2':
     resolution: {integrity: sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==}
     peerDependencies:
@@ -1501,6 +1628,13 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.4:
+    resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
+
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
@@ -1548,6 +1682,9 @@ packages:
   bcp-47@2.1.0:
     resolution: {integrity: sha512-9IIS3UPrvIa1Ej+lVDdDwO7zLehjqsaByECw0bu2RRGP73jALm6FYbzI5gWbgHLvNdkvfXB5YrSbocZdOS0c0w==}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -1584,6 +1721,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1733,6 +1874,10 @@ packages:
     resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
     engines: {node: '>=12'}
 
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -1753,6 +1898,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -1834,6 +1982,10 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -1998,11 +2150,19 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
   expressive-code@0.42.0:
     resolution: {integrity: sha512-V5DtJLEKuj4wf9O6IRtPtRObkMVy2ggR+S0MdjrTw6m58krZnDioyhW1si3Y04c5YPeooP4nd85Yq9NwEVHS4g==}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fake-indexeddb@6.2.5:
+    resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
+    engines: {node: '>=18'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2217,6 +2377,13 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
 
@@ -2369,6 +2536,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -2415,9 +2585,24 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2425,6 +2610,15 @@ packages:
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2506,6 +2700,10 @@ packages:
 
   magicast@0.5.3:
     resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
@@ -2835,6 +3033,9 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2845,6 +3046,9 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   piccolore@0.1.3:
     resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
@@ -3002,6 +3206,10 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -3053,6 +3261,10 @@ packages:
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -3110,6 +3322,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -3144,6 +3359,12 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -3213,8 +3434,14 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
   tinyclip@0.1.14:
     resolution: {integrity: sha512-F1oWdz8tjT17qe1d5JgDK6z03WGOhYYAN0lK3/D/fzNiy93xswLLEw7pk+3g05onhAy6Bsc6PLNUGhdgVjemMQ==}
@@ -3227,6 +3454,25 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.4.2:
+    resolution: {integrity: sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==}
+
+  tldts@7.4.2:
+    resolution: {integrity: sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==}
+    hasBin: true
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -3297,6 +3543,10 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici@7.27.2:
+    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
+    engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -3510,8 +3760,65 @@ packages:
       vite:
         optional: true
 
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -3538,6 +3845,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -3549,6 +3861,13 @@ packages:
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
@@ -3613,6 +3932,26 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.3(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@astrojs/compiler@4.0.0': {}
 
@@ -3825,7 +4164,7 @@ snapshots:
   '@babel/helper-module-imports@7.28.6':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -3901,6 +4240,12 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@bcoe/v8-coverage@1.0.2': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@capsizecss/unpack@4.0.0':
     dependencies:
       fontkitten: 1.0.3
@@ -3918,6 +4263,30 @@ snapshots:
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.3(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.5(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@ctrl/tinycolor@4.2.0': {}
 
@@ -4127,6 +4496,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.1': {}
 
   '@expressive-code/core@0.42.0':
     dependencies:
@@ -4476,6 +4847,8 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tauri-apps/api@2.11.0': {}
 
   '@tauri-apps/cli-darwin-arm64@2.11.0':
@@ -4566,6 +4939,11 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/d3-color@3.1.3': {}
 
   '@types/d3-drag@3.0.7':
@@ -4590,6 +4968,8 @@ snapshots:
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -4761,6 +5141,61 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.8
+      ast-v8-to-istanbul: 1.0.4
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.2
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@types/node@24.13.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@6.4.2(@types/node@24.13.1)(yaml@2.9.0))
+
+  '@vitest/expect@4.1.8':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.8(vite@6.4.2(@types/node@24.13.1)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.2(@types/node@24.13.1)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.8':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.8':
+    dependencies:
+      '@vitest/utils': 4.1.8
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.8': {}
+
+  '@vitest/utils@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@xyflow/react@12.10.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@xyflow/system': 0.0.76
@@ -4878,6 +5313,14 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
+
+  assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.4:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   astring@1.9.0: {}
 
@@ -5003,6 +5446,10 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   boolbase@1.0.0: {}
 
   brace-expansion@1.1.15:
@@ -5044,6 +5491,8 @@ snapshots:
   caniuse-lite@1.0.30001791: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -5175,6 +5624,13 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -5196,6 +5652,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -5270,6 +5728,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  entities@8.0.0: {}
 
   environment@1.1.0: {}
 
@@ -5593,6 +6053,8 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  expect-type@1.3.0: {}
+
   expressive-code@0.42.0:
     dependencies:
       '@expressive-code/core': 0.42.0
@@ -5601,6 +6063,8 @@ snapshots:
       '@expressive-code/plugin-text-markers': 0.42.0
 
   extend@3.0.2: {}
+
+  fake-indexeddb@6.2.5: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -5942,6 +6406,14 @@ snapshots:
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  html-escaper@2.0.2: {}
+
   html-escaper@3.0.3: {}
 
   html-to-image@1.11.13: {}
@@ -6073,6 +6545,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -6120,6 +6594,19 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -6129,11 +6616,39 @@ snapshots:
       has-symbols: 1.1.0
       set-function-name: 2.0.2
 
+  js-tokens@10.0.0: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.5(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.1
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.27.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -6217,8 +6732,12 @@ snapshots:
   magicast@0.5.3:
     dependencies:
       '@babel/parser': 7.29.7
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.1
 
   markdown-extensions@2.0.0: {}
 
@@ -6861,11 +7380,17 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  pathe@2.0.3: {}
 
   piccolore@0.1.3: {}
 
@@ -7087,6 +7612,8 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  require-from-string@2.0.2: {}
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -7183,6 +7710,10 @@ snapshots:
       is-regex: 1.2.1
 
   sax@1.6.0: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.23.2:
     dependencies:
@@ -7290,6 +7821,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   sisteransi@1.0.5: {}
@@ -7318,6 +7851,10 @@ snapshots:
   source-map@0.7.6: {}
 
   space-separated-tokens@2.0.2: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -7418,7 +7955,11 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.6.0
 
+  symbol-tree@3.2.4: {}
+
   tiny-inflate@1.0.3: {}
+
+  tinybench@2.9.0: {}
 
   tinyclip@0.1.14: {}
 
@@ -7428,6 +7969,22 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  tldts-core@7.4.2: {}
+
+  tldts@7.4.2:
+    dependencies:
+      tldts-core: 7.4.2
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.4.2
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -7508,6 +8065,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.18.2: {}
+
+  undici@7.27.2: {}
 
   unified@11.0.5:
     dependencies:
@@ -7643,7 +8202,52 @@ snapshots:
     optionalDependencies:
       vite: 7.3.5(@types/node@24.13.1)(yaml@2.9.0)
 
+  vitest@4.1.8(@types/node@24.13.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@6.4.2(@types/node@24.13.1)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@6.4.2(@types/node@24.13.1)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.2
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 6.4.2(@types/node@24.13.1)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.13.1
+      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   web-namespaces@2.0.1: {}
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -7692,6 +8296,11 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   word-wrap@1.2.5: {}
 
   wrap-ansi@10.0.0:
@@ -7705,6 +8314,10 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xxhash-wasm@1.1.0: {}
 

--- a/src/lib/graphClipboard.test.ts
+++ b/src/lib/graphClipboard.test.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+import type { Edge, Node } from '@xyflow/react'
+import { defaultConceptReviewFields, type ConceptNodeData } from '@/types/graph'
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  advanceClipboardAfterPaste,
+  getGraphClipboard,
+  instantiateClipboard,
+  setGraphClipboard,
+  snapshotSelection,
+  type GraphClipboard,
+} from './graphClipboard'
+
+function node(id: string, x = 0, y = 0): Node<ConceptNodeData> {
+  return { id, position: { x, y }, data: { text: id, ...defaultConceptReviewFields() } }
+}
+
+function edge(id: string, source: string, target: string): Edge {
+  return { id, source, target, type: 'nesso', data: { type: 'causes' } }
+}
+
+const nodes = [node('n1'), node('n2'), node('n3')]
+const edges = [edge('e1', 'n1', 'n2'), edge('e2', 'n2', 'n3')]
+
+beforeEach(() => setGraphClipboard(null))
+
+describe('snapshotSelection', () => {
+  it('captures selected nodes plus the edges fully internal to them', () => {
+    const snap = snapshotSelection({
+      nodes,
+      edges,
+      selected: null,
+      selectedIds: ['n1', 'n2'],
+    })
+    expect(snap?.nodes.map((n) => n.id)).toEqual(['n1', 'n2'])
+    expect(snap?.edges.map((e) => e.id)).toEqual(['e1'])
+  })
+
+  it('for an edge-only selection, pulls in the edge endpoints', () => {
+    const snap = snapshotSelection({
+      nodes,
+      edges,
+      selected: { kind: 'edge', id: 'e1' },
+      selectedIds: [],
+    })
+    expect(snap?.nodes.map((n) => n.id).sort()).toEqual(['n1', 'n2'])
+    expect(snap?.edges.map((e) => e.id)).toEqual(['e1'])
+  })
+
+  it('strips the selected flag from snapshotted nodes and edges', () => {
+    const snap = snapshotSelection({
+      nodes: [{ ...node('n1'), selected: true }],
+      edges: [],
+      selected: { kind: 'node', id: 'n1' },
+      selectedIds: ['n1'],
+    })
+    expect('selected' in (snap?.nodes[0] ?? {})).toBe(false)
+  })
+
+  it('returns null when nothing is selected', () => {
+    expect(snapshotSelection({ nodes, edges, selected: null, selectedIds: [] })).toBeNull()
+  })
+})
+
+describe('instantiateClipboard', () => {
+  const clip: GraphClipboard = {
+    nodes: [node('n1', 10, 10), node('n2', 20, 20)],
+    edges: [edge('e1', 'n1', 'n2')],
+  }
+
+  it('assigns fresh ids, remaps edge endpoints, and offsets positions', () => {
+    const { nodes: out, edges: outEdges } = instantiateClipboard(clip, new Set(), new Set())
+    expect(out.map((n) => n.id)).not.toEqual(['n1', 'n2'])
+    expect(out.every((n) => n.id.startsWith('n'))).toBe(true)
+    expect(out[0].position).toEqual({ x: 58, y: 58 })
+    expect(out.every((n) => n.selected)).toBe(true)
+
+    // The pasted edge points at the remapped node ids, not the originals.
+    const ids = out.map((n) => n.id)
+    expect(ids).toContain(outEdges[0].source)
+    expect(ids).toContain(outEdges[0].target)
+    expect(outEdges[0].type).toBe('nesso')
+    expect(outEdges[0].selected).toBe(false)
+  })
+
+  it('avoids ids already present in the used sets', () => {
+    const used = new Set(['n1', 'n2'])
+    const { nodes: out } = instantiateClipboard(clip, used, new Set())
+    for (const n of out) expect(['n1', 'n2']).not.toContain(n.id)
+  })
+})
+
+describe('advanceClipboardAfterPaste', () => {
+  it('cascades clipboard node positions so a repeat paste does not stack', () => {
+    setGraphClipboard({ nodes: [node('n1', 0, 0)], edges: [] })
+    advanceClipboardAfterPaste()
+    expect(getGraphClipboard()?.nodes[0].position).toEqual({ x: 48, y: 48 })
+  })
+
+  it('is a no-op when the clipboard is empty', () => {
+    setGraphClipboard(null)
+    advanceClipboardAfterPaste()
+    expect(getGraphClipboard()).toBeNull()
+  })
+})

--- a/src/lib/graphId.test.ts
+++ b/src/lib/graphId.test.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+import { describe, expect, it } from 'vitest'
+import { isGraphId, newElementId, newGraphId } from './graphId'
+
+describe('newGraphId', () => {
+  it('produces a `g` + 13 lowercase-alphanumeric id', () => {
+    for (let i = 0; i < 50; i++) {
+      const id = newGraphId()
+      expect(id).toMatch(/^g[a-z0-9]{13}$/)
+      expect(isGraphId(id)).toBe(true)
+    }
+  })
+
+  it('is overwhelmingly unique across many calls', () => {
+    const ids = new Set(Array.from({ length: 1000 }, () => newGraphId()))
+    expect(ids.size).toBe(1000)
+  })
+})
+
+describe('isGraphId', () => {
+  it('rejects malformed ids', () => {
+    expect(isGraphId('')).toBe(false)
+    expect(isGraphId('g')).toBe(false)
+    expect(isGraphId('xabcdefghijklm')).toBe(false) // wrong prefix
+    expect(isGraphId('gABCDEFGHIJKLM')).toBe(false) // uppercase
+    expect(isGraphId('gabc')).toBe(false) // too short
+    expect(isGraphId('gabcdefghijklmn')).toBe(false) // too long
+  })
+})
+
+describe('newElementId', () => {
+  it('prefixes node and edge ids and stays out of the used set', () => {
+    const node = newElementId('n', new Set())
+    expect(node).toMatch(/^n[a-z0-9]{5}$/)
+    const edge = newElementId('e', new Set())
+    expect(edge).toMatch(/^e[a-z0-9]{5}$/)
+  })
+
+  it('never returns an id already present in the used set', () => {
+    const used = new Set<string>()
+    for (let i = 0; i < 200; i++) {
+      const id = newElementId('n', used)
+      expect(used.has(id)).toBe(false)
+      used.add(id)
+    }
+    expect(used.size).toBe(200)
+  })
+})

--- a/src/lib/workspace/graphFiles.test.ts
+++ b/src/lib/workspace/graphFiles.test.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+import { deserializeGraph } from '@nesso-how/formats'
+import { describe, expect, it } from 'vitest'
+import type { GraphRecord } from '@/store/db'
+import { defaultConceptReviewFields } from '@/types/graph'
+import {
+  filenameBaseFromName,
+  graphNameFromFilename,
+  recordToGraphFile,
+  uniqueGraphNameAmong,
+} from './graphFiles'
+
+describe('filenameBaseFromName', () => {
+  it('keeps spaces but strips path-forbidden characters', () => {
+    expect(filenameBaseFromName('My Graph')).toBe('My Graph')
+    expect(filenameBaseFromName('a/b:c|d')).toBe('a-b-c-d')
+    expect(filenameBaseFromName('  trimmed  ')).toBe('trimmed')
+  })
+
+  it('falls back to `graph` only when the result would be empty', () => {
+    expect(filenameBaseFromName('')).toBe('graph')
+    expect(filenameBaseFromName('   ')).toBe('graph')
+    // All-forbidden chars become dashes, which is non-empty, so no fallback.
+    expect(filenameBaseFromName('???')).toBe('---')
+  })
+})
+
+describe('graphNameFromFilename', () => {
+  it('drops the .json extension case-insensitively', () => {
+    expect(graphNameFromFilename('Foo.json')).toBe('Foo')
+    expect(graphNameFromFilename('Foo.JSON')).toBe('Foo')
+    expect(graphNameFromFilename('No extension')).toBe('No extension')
+  })
+
+  it('falls back to Untitled for an empty stem', () => {
+    expect(graphNameFromFilename('.json')).toBe('Untitled')
+  })
+})
+
+describe('uniqueGraphNameAmong', () => {
+  it('returns the name unchanged when it is free', () => {
+    expect(uniqueGraphNameAmong('Foo', [])).toBe('Foo')
+    expect(uniqueGraphNameAmong('Foo', ['Bar'])).toBe('Foo')
+  })
+
+  it('suffixes with the first free -N, case-insensitively', () => {
+    expect(uniqueGraphNameAmong('Foo', ['Foo'])).toBe('Foo-2')
+    expect(uniqueGraphNameAmong('Foo', ['foo', 'Foo-2'])).toBe('Foo-3')
+  })
+
+  it('defaults a blank name to `graph`', () => {
+    expect(uniqueGraphNameAmong('   ', [])).toBe('graph')
+  })
+})
+
+describe('recordToGraphFile', () => {
+  const record: GraphRecord = {
+    id: 'g0000000000001',
+    name: 'Demo',
+    createdAt: 1,
+    updatedAt: 42,
+    nodes: [
+      {
+        id: 'n1',
+        position: { x: 0, y: 0 },
+        selected: true,
+        data: { text: 'A', ...defaultConceptReviewFields() },
+      },
+    ],
+    edges: [{ id: 'e1', source: 'n1', target: 'n1', type: 'nesso', selected: true }],
+  }
+
+  it('serializes to a deserializable Nesso graph file carrying id, name and updatedAt', () => {
+    const parsed = deserializeGraph(recordToGraphFile(record))
+    expect(parsed).toMatchObject({ id: 'g0000000000001', name: 'Demo', updatedAt: 42 })
+    expect(parsed.nodes).toHaveLength(1)
+    expect(parsed.edges).toHaveLength(1)
+  })
+
+  it('strips the transient `selected` flag from nodes and edges', () => {
+    const parsed = deserializeGraph(recordToGraphFile(record))
+    expect('selected' in parsed.nodes[0]).toBe(false)
+    expect('selected' in parsed.edges[0]).toBe(false)
+  })
+})

--- a/src/lib/workspace/manifest.test.ts
+++ b/src/lib/workspace/manifest.test.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+import { describe, expect, it } from 'vitest'
+import {
+  buildFileToIdMap,
+  getDiskSyncCache,
+  isManifestOnlyWatchPaths,
+  setDiskSyncCache,
+  upsertManifestEntry,
+  type WorkspaceManifest,
+} from './manifest'
+
+function manifest(): WorkspaceManifest {
+  return {
+    version: 1,
+    entries: {
+      g1: { id: 'g1', file: 'a.json', name: 'A', updatedAt: 1 },
+      g2: { id: 'g2', file: 'b.json', name: 'B', updatedAt: 2 },
+    },
+  }
+}
+
+describe('isManifestOnlyWatchPaths', () => {
+  it('is true only when every path is the workspace manifest file', () => {
+    expect(isManifestOnlyWatchPaths(['/ws/.nesso/manifest.json'])).toBe(true)
+    expect(isManifestOnlyWatchPaths(['C:\\ws\\.nesso\\manifest.json'])).toBe(true)
+  })
+
+  it('is false for empty input or any non-manifest path', () => {
+    expect(isManifestOnlyWatchPaths([])).toBe(false)
+    expect(isManifestOnlyWatchPaths(['/ws/.nesso/manifest.json', '/ws/graphs/a.json'])).toBe(false)
+    expect(isManifestOnlyWatchPaths(['/ws/graphs/a.json'])).toBe(false)
+  })
+})
+
+describe('buildFileToIdMap', () => {
+  it('maps each entry file to its graph id', () => {
+    const map = buildFileToIdMap(manifest())
+    expect(map.get('a.json')).toBe('g1')
+    expect(map.get('b.json')).toBe('g2')
+    expect(map.size).toBe(2)
+  })
+})
+
+describe('upsertManifestEntry', () => {
+  it('inserts a new entry and reports a change', () => {
+    const m = manifest()
+    expect(upsertManifestEntry(m, 'g3', 'c.json', 'C', 3)).toBe(true)
+    expect(m.entries.g3).toEqual({ id: 'g3', file: 'c.json', name: 'C', updatedAt: 3 })
+  })
+
+  it('updates an existing entry when a field differs', () => {
+    const m = manifest()
+    expect(upsertManifestEntry(m, 'g1', 'a.json', 'A renamed', 1)).toBe(true)
+    expect(m.entries.g1.name).toBe('A renamed')
+  })
+
+  it('returns false and leaves the manifest untouched when nothing changed', () => {
+    const m = manifest()
+    expect(upsertManifestEntry(m, 'g1', 'a.json', 'A', 1)).toBe(false)
+  })
+})
+
+describe('disk-sync cache', () => {
+  it('round-trips the active workspace and manifest', () => {
+    const m = manifest()
+    setDiskSyncCache('/ws', m)
+    const cache = getDiskSyncCache()
+    expect(cache.workspace).toBe('/ws')
+    expect(cache.manifest).toBe(m)
+  })
+})

--- a/src/lib/workspace/paths.test.ts
+++ b/src/lib/workspace/paths.test.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+import { describe, expect, it } from 'vitest'
+import { joinPath, normalizePath, projectDisplayName, projectNameFromPath } from './paths'
+
+describe('joinPath', () => {
+  it('joins parts with a single slash and drops empty segments', () => {
+    expect(joinPath('a', 'b', 'c')).toBe('a/b/c')
+    expect(joinPath('a', '', 'c')).toBe('a/c')
+    expect(joinPath('/root', 'graphs')).toBe('/root/graphs')
+  })
+
+  it('collapses redundant slashes', () => {
+    expect(joinPath('a//b', 'c')).toBe('a/b/c')
+  })
+
+  it('preserves a leading double slash for Windows UNC paths', () => {
+    expect(joinPath('//server', 'share')).toBe('//server/share')
+  })
+})
+
+describe('normalizePath', () => {
+  it('strips trailing slashes', () => {
+    expect(normalizePath('/a/b/')).toBe('/a/b')
+    expect(normalizePath('/a/b///')).toBe('/a/b')
+    expect(normalizePath('/a/b')).toBe('/a/b')
+  })
+})
+
+describe('projectNameFromPath', () => {
+  it('returns the folder basename for posix paths', () => {
+    expect(projectNameFromPath('/home/user/My Project')).toBe('My Project')
+  })
+
+  it('handles backslash separators', () => {
+    expect(projectNameFromPath('C:\\Users\\me\\proj')).toBe('proj')
+  })
+
+  it('ignores a trailing slash', () => {
+    expect(projectNameFromPath('/home/user/proj/')).toBe('proj')
+  })
+})
+
+describe('projectDisplayName', () => {
+  it('swaps the bundled default path for a friendly label', () => {
+    expect(projectDisplayName('/app/data/graphs', '/app/data/graphs', 'My Graphs')).toBe(
+      'My Graphs',
+    )
+    // Trailing-slash difference still resolves to the default.
+    expect(projectDisplayName('/app/data/graphs/', '/app/data/graphs', 'My Graphs')).toBe(
+      'My Graphs',
+    )
+  })
+
+  it('falls back to the folder basename for any other path', () => {
+    expect(projectDisplayName('/home/user/other', '/app/data/graphs', 'My Graphs')).toBe('other')
+    expect(projectDisplayName('/home/user/other', null, 'My Graphs')).toBe('other')
+  })
+})

--- a/src/lib/workspace/sync.test.ts
+++ b/src/lib/workspace/sync.test.ts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+import 'fake-indexeddb/auto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { tauriFsState } from '@/test/fakeTauriFs'
+
+// Workspace logic (sync, graphFiles, manifest) runs for real against an
+// in-memory filesystem; only the Tauri boundary is mocked. These are true
+// integration tests of the disk<->IndexedDB merge.
+vi.mock('@tauri-apps/plugin-fs', async () => (await import('@/test/fakeTauriFs')).fakeFsPlugin)
+vi.mock('@tauri-apps/api/path', async () => (await import('@/test/fakeTauriFs')).fakePathApi)
+vi.mock('@tauri-apps/api/core', async () => (await import('@/test/fakeTauriFs')).fakeCoreApi)
+
+import { resolveWorkspace } from '@/lib/workspace/paths'
+import { setDiskSyncCache } from '@/lib/workspace/manifest'
+import { loadProjectFromDisk, persistWorkspaceSync } from '@/lib/workspace/sync'
+import { dbClearGraphs, dbListGraphs, dbSaveGraph, type GraphRecord } from '@/store/db'
+
+const SETTINGS = { activeProjectPath: '/proj' }
+
+function gid(n: number): string {
+  return `g${String(n).padStart(13, '0')}`
+}
+
+function record(id: string, name: string, updatedAt: number): GraphRecord {
+  return { id, name, createdAt: updatedAt, updatedAt, nodes: [], edges: [] }
+}
+
+function writeDiskFile(filename: string, file: { id?: string; name: string; updatedAt?: number }) {
+  tauriFsState.writeFile(`/proj/${filename}`, JSON.stringify({ ...file, nodes: [], edges: [] }))
+}
+
+function writeDiskManifest(entries: Record<string, GraphRecord & { file: string }>) {
+  const manifestEntries: Record<string, unknown> = {}
+  for (const [id, e] of Object.entries(entries)) {
+    manifestEntries[id] = { id, file: e.file, name: e.name, updatedAt: e.updatedAt }
+  }
+  tauriFsState.writeFile(
+    '/proj/.nesso/manifest.json',
+    JSON.stringify({ version: 1, entries: manifestEntries }),
+  )
+}
+
+async function ws() {
+  return resolveWorkspace(SETTINGS)
+}
+
+beforeEach(async () => {
+  tauriFsState.reset()
+  await dbClearGraphs()
+  setDiskSyncCache('', { version: 1, entries: {} })
+})
+
+describe('loadProjectFromDisk', () => {
+  it('imports every on-disk graph file into IndexedDB', async () => {
+    writeDiskFile('Alpha.json', { id: gid(1), name: 'Alpha', updatedAt: 1000 })
+    writeDiskFile('Beta.json', { id: gid(2), name: 'Beta', updatedAt: 2000 })
+
+    const list = await loadProjectFromDisk(await ws())
+
+    expect(list.map((r) => r.name).sort()).toEqual(['Alpha', 'Beta'])
+    const inDb = await dbListGraphs()
+    expect(inDb.map((r) => r.id).sort()).toEqual([gid(1), gid(2)])
+  })
+})
+
+describe('persistWorkspaceSync', () => {
+  it('writes an IDB-only record out to disk and tracks it in the manifest', async () => {
+    await dbSaveGraph(record(gid(1), 'Solo', 1000))
+
+    await persistWorkspaceSync(SETTINGS, await dbListGraphs())
+
+    expect(tauriFsState.files.has('/proj/Solo.json')).toBe(true)
+    const manifest = JSON.parse(tauriFsState.files.get('/proj/.nesso/manifest.json')!)
+    expect(manifest.entries[gid(1)]).toMatchObject({ file: 'Solo.json', name: 'Solo' })
+  })
+
+  it('picks up a disk file that is newer than its IndexedDB copy', async () => {
+    await dbSaveGraph(record(gid(1), 'Doc', 1000))
+    writeDiskFile('Doc.json', { id: gid(1), name: 'Doc', updatedAt: 5000 })
+
+    await persistWorkspaceSync(SETTINGS, await dbListGraphs())
+
+    const [stored] = await dbListGraphs()
+    expect(stored.updatedAt).toBe(5000)
+  })
+
+  it('drops a tracked graph whose file was deleted outside the app', async () => {
+    await dbSaveGraph(record(gid(1), 'Gone', 1000))
+    writeDiskManifest({ [gid(1)]: { ...record(gid(1), 'Gone', 1000), file: 'Gone.json' } })
+
+    const list = await persistWorkspaceSync(SETTINGS, await dbListGraphs())
+
+    expect(list).toHaveLength(0)
+    expect(await dbListGraphs()).toHaveLength(0)
+  })
+
+  it('de-duplicates a disk graph whose name collides with an IDB peer', async () => {
+    await dbSaveGraph(record(gid(1), 'Foo', 1000))
+    writeDiskFile('Foo.json', { id: gid(2), name: 'Foo', updatedAt: 1000 })
+
+    const list = await persistWorkspaceSync(SETTINGS, await dbListGraphs())
+
+    expect(list.map((r) => r.name).sort()).toEqual(['Foo', 'Foo-2'])
+    // The renamed graph's file follows its de-duplicated name.
+    expect(tauriFsState.files.has('/proj/Foo-2.json')).toBe(true)
+  })
+})

--- a/src/store/slices/graph-editing.test.ts
+++ b/src/store/slices/graph-editing.test.ts
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+// SPDX-License-Identifier: MIT
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createStore } from 'zustand/vanilla'
+import { setGraphClipboard } from '@/lib/graphClipboard'
+import type { GraphState } from '../state'
+import { createGraphEditingSlice } from './graph-editing'
+import { createSettingsSlice } from './settings'
+
+// A headless store composed from the editing + settings slices — enough to
+// exercise every graph mutation without the persist middleware, IndexedDB, or
+// React Flow rendering.
+function makeStore() {
+  return createStore<GraphState>()(
+    (...a) =>
+      ({
+        ...createGraphEditingSlice(...a),
+        ...createSettingsSlice(...a),
+      }) as GraphState,
+  )
+}
+
+type Store = ReturnType<typeof makeStore>
+
+beforeEach(() => setGraphClipboard(null))
+
+describe('addNode', () => {
+  it('inserts a selected, editing concept and returns its id', () => {
+    const s: Store = makeStore()
+    const id = s.getState().addNode(10, 20)
+    const state = s.getState()
+    expect(state.nodes).toHaveLength(1)
+    expect(state.nodes[0]).toMatchObject({ id, position: { x: 10, y: 20 }, selected: true })
+    expect(state.nodes[0].data.text).toBe('New concept')
+    expect(state.selected).toEqual({ kind: 'node', id })
+    expect(state.selectedIds).toEqual([id])
+    expect(state.editNodeId).toBe(id)
+  })
+
+  it('deselects a previously selected node', () => {
+    const s = makeStore()
+    const first = s.getState().addNode()
+    s.getState().addNode()
+    expect(s.getState().nodes.find((n) => n.id === first)?.selected).toBe(false)
+  })
+})
+
+describe('addEdge', () => {
+  it('creates a selected nesso edge between two nodes', () => {
+    const s = makeStore()
+    const a = s.getState().addNode()
+    const b = s.getState().addNode()
+    const id = s.getState().addEdge(a, b, 'causes')
+    const edge = s.getState().edges.find((e) => e.id === id)
+    expect(edge).toMatchObject({
+      source: a,
+      target: b,
+      type: 'nesso',
+      sourceHandle: 'out',
+      targetHandle: 'in',
+      selected: true,
+    })
+    expect(edge?.data).toMatchObject({ type: 'causes' })
+    expect(s.getState().selected).toEqual({ kind: 'edge', id })
+  })
+})
+
+describe('deleteNode', () => {
+  it('removes the node, all incident edges, and clears its selection', () => {
+    const s = makeStore()
+    const a = s.getState().addNode()
+    const b = s.getState().addNode()
+    s.getState().addEdge(a, b, 'causes')
+    s.getState().setSelected({ kind: 'node', id: a })
+    s.getState().deleteNode(a)
+    const state = s.getState()
+    expect(state.nodes.map((n) => n.id)).toEqual([b])
+    expect(state.edges).toHaveLength(0)
+    expect(state.selected).toBeNull()
+  })
+})
+
+describe('deleteEdge', () => {
+  it('removes the edge and clears its selection', () => {
+    const s = makeStore()
+    const a = s.getState().addNode()
+    const b = s.getState().addNode()
+    const id = s.getState().addEdge(a, b, 'causes')
+    s.getState().deleteEdge(id)
+    expect(s.getState().edges).toHaveLength(0)
+    expect(s.getState().selected).toBeNull()
+  })
+})
+
+describe('updateNodeData', () => {
+  it('merges the patch into the node data', () => {
+    const s = makeStore()
+    const id = s.getState().addNode()
+    s.getState().updateNodeData(id, { text: 'Renamed', stability: 5 })
+    const data = s.getState().nodes[0].data
+    expect(data.text).toBe('Renamed')
+    expect(data.stability).toBe(5)
+  })
+})
+
+describe('deleteSelection', () => {
+  it('drops the selected node together with edges touching it', () => {
+    const s = makeStore()
+    const a = s.getState().addNode()
+    const b = s.getState().addNode()
+    s.getState().addEdge(a, b, 'causes')
+    s.getState().setSelected({ kind: 'node', id: a })
+    s.getState().deleteSelection()
+    expect(s.getState().nodes.map((n) => n.id)).toEqual([b])
+    expect(s.getState().edges).toHaveLength(0)
+    expect(s.getState().selected).toBeNull()
+  })
+})
+
+describe('undo / redo', () => {
+  it('reverts and reapplies the last mutation', () => {
+    const s = makeStore()
+    s.getState().addNode()
+    expect(s.getState().nodes).toHaveLength(1)
+    s.getState().undo()
+    expect(s.getState().nodes).toHaveLength(0)
+    s.getState().redo()
+    expect(s.getState().nodes).toHaveLength(1)
+  })
+})
+
+describe('copySelection / pasteSelection', () => {
+  it('duplicates the selected subgraph with fresh ids and an offset', () => {
+    const s = makeStore()
+    const a = s.getState().addNode(0, 0)
+    const b = s.getState().addNode(100, 0)
+    s.getState().addEdge(a, b, 'causes')
+    s.getState().setSelected(null)
+    s.getState().setSelectedIds([a, b])
+
+    expect(s.getState().copySelection()).toBe(true)
+    expect(s.getState().pasteAvailable).toBe(true)
+
+    const pasted = s.getState().pasteSelection()
+    expect(pasted).toHaveLength(2)
+    expect(s.getState().nodes).toHaveLength(4)
+    expect(s.getState().edges).toHaveLength(2)
+
+    const original = new Set([a, b])
+    for (const id of pasted ?? []) expect(original.has(id)).toBe(false)
+  })
+})

--- a/src/store/slices/graph-management.desktop.test.ts
+++ b/src/store/slices/graph-management.desktop.test.ts
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+// SPDX-License-Identifier: MIT
+import 'fake-indexeddb/auto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createStore } from 'zustand/vanilla'
+import { tauriFsState } from '@/test/fakeTauriFs'
+
+vi.mock('@tauri-apps/plugin-fs', async () => (await import('@/test/fakeTauriFs')).fakeFsPlugin)
+vi.mock('@tauri-apps/api/path', async () => (await import('@/test/fakeTauriFs')).fakePathApi)
+vi.mock('@tauri-apps/api/core', async () => (await import('@/test/fakeTauriFs')).fakeCoreApi)
+vi.mock('@tauri-apps/plugin-dialog', async () => (await import('@/test/fakeTauriFs')).fakeDialogApi)
+
+import { setDiskSyncCache } from '@/lib/workspace/manifest'
+import { dbClearGraphs, dbListGraphs, dbLoadGraph } from '@/store/db'
+import type { GraphState } from '../state'
+import { createDesktopSyncSlice } from './desktop-sync'
+import { createGraphEditingSlice } from './graph-editing'
+import { createGraphManagementSlice } from './graph-management'
+import { createSettingsSlice } from './settings'
+import { createUISlice } from './ui'
+
+// Desktop mode: `__TAURI_INTERNALS__` on window flips `isDesktop()` true, so the
+// store drives the real workspace layer (disk is the source of truth) against the
+// in-memory fake fs + fake-indexeddb.
+const DEFAULT_WS = '/appdata/graphs'
+
+function makeStore() {
+  return createStore<GraphState>()(
+    (...a) =>
+      ({
+        ...createGraphEditingSlice(...a),
+        ...createSettingsSlice(...a),
+        ...createUISlice(...a),
+        ...createGraphManagementSlice(...a),
+        ...createDesktopSyncSlice(...a),
+      }) as GraphState,
+  )
+}
+
+type Store = ReturnType<typeof makeStore>
+
+function gid(n: number): string {
+  return `g${String(n).padStart(13, '0')}`
+}
+
+/** Mirror app startup: seed the default project, then load the active graph. */
+async function boot(): Promise<Store> {
+  const s = makeStore()
+  await s.getState().loadGraphList()
+  await s.getState().loadGraph(s.getState().currentGraphId)
+  return s
+}
+
+beforeEach(async () => {
+  tauriFsState.reset()
+  await dbClearGraphs()
+  setDiskSyncCache('', { version: 1, entries: {} })
+  ;(window as unknown as { __TAURI_INTERNALS__?: object }).__TAURI_INTERNALS__ = {}
+})
+
+describe('loadGraphList (desktop)', () => {
+  it('resolves the default project and writes the seeded graphs to disk', async () => {
+    const s = makeStore()
+    const list = await s.getState().loadGraphList()
+
+    expect(list.length).toBeGreaterThan(0)
+    expect(s.getState().settings.activeProjectPath).toBe(DEFAULT_WS)
+    const wroteSeed = [...tauriFsState.files.keys()].some(
+      (p) => p.startsWith(`${DEFAULT_WS}/`) && p.endsWith('.json'),
+    )
+    expect(wroteSeed).toBe(true)
+  })
+})
+
+describe('createProject', () => {
+  it('creates the folder, switches to it, and seeds one empty graph on disk', async () => {
+    const s = await boot()
+    tauriFsState.setDialogResult('/newproj')
+
+    await s.getState().createProject()
+
+    expect(s.getState().settings.activeProjectPath).toBe('/newproj')
+    expect(s.getState().settings.knownProjects).toContain('/newproj')
+    const list = s.getState().graphList
+    expect(list).toHaveLength(1)
+    expect(tauriFsState.files.has(`/newproj/${list[0].name}.json`)).toBe(true)
+  })
+})
+
+describe('switchProject', () => {
+  it('loads the graphs already present in the target folder', async () => {
+    const s = await boot()
+    tauriFsState.dirs.add('/other')
+    tauriFsState.writeFile(
+      '/other/Imported.json',
+      JSON.stringify({ id: gid(1), name: 'Imported', updatedAt: 1000, nodes: [], edges: [] }),
+    )
+
+    await s.getState().switchProject('/other')
+
+    expect(s.getState().settings.activeProjectPath).toBe('/other')
+    expect(s.getState().graphList.map((g) => g.name)).toEqual(['Imported'])
+    expect((await dbLoadGraph(gid(1)))?.name).toBe('Imported')
+  })
+})
+
+describe('deleteGraph (desktop)', () => {
+  it('removes the graph file from disk', async () => {
+    const s = await boot()
+    const id = await s.getState().createGraph('ToDelete')
+    expect(tauriFsState.files.has(`${DEFAULT_WS}/ToDelete.json`)).toBe(true)
+
+    await s.getState().deleteGraph(id)
+
+    expect(tauriFsState.files.has(`${DEFAULT_WS}/ToDelete.json`)).toBe(false)
+    expect(await dbLoadGraph(id)).toBeUndefined()
+  })
+})
+
+describe('renameGraph (desktop)', () => {
+  it('relocates the file on disk to follow the new name', async () => {
+    const s = await boot()
+    const id = await s.getState().createGraph('OldName')
+
+    await s.getState().renameGraph(id, 'NewName')
+
+    expect(tauriFsState.files.has(`${DEFAULT_WS}/NewName.json`)).toBe(true)
+    expect(tauriFsState.files.has(`${DEFAULT_WS}/OldName.json`)).toBe(false)
+    expect((await dbLoadGraph(id))?.name).toBe('NewName')
+  })
+})
+
+describe('reloadActiveGraphFromDisk', () => {
+  it('replaces in-memory state with an externally edited file', async () => {
+    const s = await boot()
+    const id = await s.getState().createGraph('Doc')
+    expect(s.getState().nodes).toHaveLength(0)
+
+    tauriFsState.writeFile(
+      `${DEFAULT_WS}/Doc.json`,
+      JSON.stringify({
+        id,
+        name: 'Doc',
+        updatedAt: 9_999_999_999,
+        nodes: [{ id: 'n1', position: { x: 0, y: 0 }, data: { text: 'external' } }],
+        edges: [],
+      }),
+    )
+
+    await s.getState().reloadActiveGraphFromDisk()
+
+    expect(s.getState().nodes).toHaveLength(1)
+    expect(s.getState().nodes[0].data.text).toBe('external')
+  })
+})
+
+describe('keepLocalGraphChanges', () => {
+  it('clears the conflict flag and persists current state', async () => {
+    const s = await boot()
+    await s.getState().createGraph('Local')
+    s.getState().setExternalFileConflict(true)
+    s.getState().addNode()
+
+    await s.getState().keepLocalGraphChanges()
+
+    expect(s.getState().externalFileConflict).toBe(false)
+    const list = await dbListGraphs()
+    const stored = list.find((r) => r.id === s.getState().currentGraphId)
+    expect(stored?.nodes).toHaveLength(1)
+  })
+})

--- a/src/store/slices/graph-management.test.ts
+++ b/src/store/slices/graph-management.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+// SPDX-License-Identifier: MIT
+import 'fake-indexeddb/auto'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createStore } from 'zustand/vanilla'
+import { dbClearGraphs, dbLoadGraph } from '@/store/db'
+import type { GraphState } from '../state'
+import { createDesktopSyncSlice } from './desktop-sync'
+import { createGraphEditingSlice } from './graph-editing'
+import { createGraphManagementSlice } from './graph-management'
+import { createSettingsSlice } from './settings'
+import { createUISlice } from './ui'
+
+// Web mode: `isDesktop()` is false under jsdom, so graph management persists
+// through IndexedDB only — no disk/Tauri involved. Graphs live in a real
+// fake-indexeddb instance.
+function makeStore() {
+  return createStore<GraphState>()(
+    (...a) =>
+      ({
+        ...createGraphEditingSlice(...a),
+        ...createSettingsSlice(...a),
+        ...createUISlice(...a),
+        ...createGraphManagementSlice(...a),
+        ...createDesktopSyncSlice(...a),
+      }) as GraphState,
+  )
+}
+
+type Store = ReturnType<typeof makeStore>
+
+async function freshStore(): Promise<Store> {
+  const s = makeStore()
+  // Seed IndexedDB from the bundled seeds so every graphList meta has a backing
+  // record (the app does this on startup).
+  await s.getState().loadGraphList()
+  return s
+}
+
+beforeEach(async () => {
+  await dbClearGraphs()
+})
+
+describe('loadGraphList', () => {
+  it('seeds IndexedDB from the bundled graphs when empty', async () => {
+    const s = makeStore()
+    const list = await s.getState().loadGraphList()
+    expect(list.length).toBeGreaterThan(0)
+    const seeded = await dbLoadGraph(list[0].id)
+    expect(seeded?.id).toBe(list[0].id)
+  })
+})
+
+describe('createGraph', () => {
+  it('creates an empty graph, selects it, and persists it to IndexedDB', async () => {
+    const s = await freshStore()
+    const id = await s.getState().createGraph('Fresh')
+    const state = s.getState()
+    expect(state.currentGraphId).toBe(id)
+    expect(state.graphList.some((g) => g.id === id && g.name === 'Fresh')).toBe(true)
+    expect(state.nodes).toHaveLength(0)
+    const stored = await dbLoadGraph(id)
+    expect(stored).toMatchObject({ id, name: 'Fresh' })
+  })
+})
+
+describe('importGraph', () => {
+  it('de-duplicates a name that collides with an existing graph', async () => {
+    const s = await freshStore()
+    await s.getState().createGraph('Foo')
+    const id = await s.getState().importGraph('Foo', [], [])
+    expect(s.getState().graphList.find((g) => g.id === id)?.name).toBe('Foo-2')
+  })
+})
+
+describe('renameGraph', () => {
+  it('updates the name in the list and in IndexedDB', async () => {
+    const s = await freshStore()
+    const id = await s.getState().createGraph('Before')
+    await s.getState().renameGraph(id, 'After')
+    expect(s.getState().graphList.find((g) => g.id === id)?.name).toBe('After')
+    expect((await dbLoadGraph(id))?.name).toBe('After')
+  })
+})
+
+describe('saveCurrentGraph', () => {
+  it('persists in-memory edits of the active graph to IndexedDB', async () => {
+    const s = await freshStore()
+    const id = await s.getState().createGraph('Editable')
+    s.getState().addNode(10, 20)
+    await s.getState().saveCurrentGraph()
+    const stored = await dbLoadGraph(id)
+    expect(stored?.nodes).toHaveLength(1)
+  })
+})
+
+describe('loadGraph', () => {
+  it('switches the active graph to the persisted snapshot', async () => {
+    const s = await freshStore()
+    const a = await s.getState().createGraph('A')
+    s.getState().addNode()
+    await s.getState().saveCurrentGraph()
+    await s.getState().createGraph('B')
+
+    await s.getState().loadGraph(a)
+    expect(s.getState().currentGraphId).toBe(a)
+    expect(s.getState().nodes).toHaveLength(1)
+  })
+})
+
+describe('deleteGraph', () => {
+  it('removes the graph from the list and IndexedDB and loads a sibling', async () => {
+    const s = await freshStore()
+    const a = await s.getState().createGraph('A')
+    const b = await s.getState().createGraph('B')
+    await s.getState().deleteGraph(b)
+    const state = s.getState()
+    expect(state.graphList.some((g) => g.id === b)).toBe(false)
+    expect(await dbLoadGraph(b)).toBeUndefined()
+    expect(state.currentGraphId).not.toBe(b)
+    expect(state.graphList.some((g) => g.id === a)).toBe(true)
+  })
+})
+
+describe('desktop project actions in web mode', () => {
+  it('are no-ops that just return the current graph list', async () => {
+    const s = await freshStore()
+    const before = s.getState().graphList
+    expect(await s.getState().createProject()).toEqual(before)
+    expect(await s.getState().openProject()).toEqual(before)
+    expect(await s.getState().switchProject('/whatever')).toEqual(before)
+  })
+})

--- a/src/test/fakeTauriFs.ts
+++ b/src/test/fakeTauriFs.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+// In-memory stand-ins for the Tauri plugins the workspace layer talks to.
+// Wire them up in a test with:
+//
+//   vi.mock('@tauri-apps/plugin-fs', async () => (await import('@/test/fakeTauriFs')).fakeFsPlugin)
+//   vi.mock('@tauri-apps/api/path', async () => (await import('@/test/fakeTauriFs')).fakePathApi)
+//   vi.mock('@tauri-apps/api/core', async () => (await import('@/test/fakeTauriFs')).fakeCoreApi)
+//   vi.mock('@tauri-apps/plugin-dialog', async () => (await import('@/test/fakeTauriFs')).fakeDialogApi)
+//
+// The static import and the dynamic imports above resolve to the same module
+// instance, so `tauriFsState` reads/asserts the same filesystem the mocks mutate.
+
+const files = new Map<string, string>()
+const dirs = new Set<string>()
+let dialogResult: string | null = null
+
+export const tauriFsState = {
+  files,
+  dirs,
+  reset(): void {
+    files.clear()
+    dirs.clear()
+    dialogResult = null
+  },
+  writeFile(path: string, content: string): void {
+    files.set(path, content)
+  },
+  /** What the next dialog `save`/`open` returns (the picked folder path, or null). */
+  setDialogResult(path: string | null): void {
+    dialogResult = path
+  },
+}
+
+export const fakePathApi = {
+  appDataDir: async (): Promise<string> => '/appdata',
+}
+
+export const fakeCoreApi = {
+  invoke: async (): Promise<void> => undefined,
+}
+
+export const fakeDialogApi = {
+  save: async (): Promise<string | null> => dialogResult,
+  open: async (): Promise<string | null> => dialogResult,
+}
+
+export const fakeFsPlugin = {
+  mkdir: async (path: string): Promise<void> => {
+    dirs.add(path)
+  },
+  readTextFile: async (path: string): Promise<string> => {
+    if (!files.has(path)) throw new Error(`ENOENT ${path}`)
+    return files.get(path)!
+  },
+  writeTextFile: async (path: string, content: string): Promise<void> => {
+    files.set(path, content)
+  },
+  readDir: async (
+    dir: string,
+  ): Promise<Array<{ name: string; isFile: boolean; isDirectory: boolean }>> => {
+    const prefix = dir.endsWith('/') ? dir : `${dir}/`
+    const names = new Map<string, boolean>()
+    for (const p of files.keys()) {
+      if (!p.startsWith(prefix)) continue
+      const rest = p.slice(prefix.length)
+      const i = rest.indexOf('/')
+      names.set(i === -1 ? rest : rest.slice(0, i), i === -1)
+    }
+    for (const d of dirs) {
+      if (!d.startsWith(prefix)) continue
+      const rest = d.slice(prefix.length)
+      if (!rest) continue
+      const i = rest.indexOf('/')
+      const name = i === -1 ? rest : rest.slice(0, i)
+      if (!names.has(name)) names.set(name, false)
+    }
+    if (names.size === 0 && !dirs.has(dir)) throw new Error(`ENOENT ${dir}`)
+    return [...names].map(([name, isFile]) => ({ name, isFile, isDirectory: !isFile }))
+  },
+  exists: async (path: string): Promise<boolean> => files.has(path) || dirs.has(path),
+  rename: async (from: string, to: string): Promise<void> => {
+    if (!files.has(from)) throw new Error(`ENOENT ${from}`)
+    files.set(to, files.get(from)!)
+    files.delete(from)
+  },
+  remove: async (path: string): Promise<void> => {
+    if (!files.has(path)) throw new Error(`ENOENT ${path}`)
+    files.delete(path)
+  },
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+import { fileURLToPath, URL } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+const fromRoot = (rel: string) => fileURLToPath(new URL(rel, import.meta.url))
+
+// Pure modules run in `node`; files that touch the store/React/DOM opt into
+// jsdom per-file with a `// @vitest-environment jsdom` docblock.
+//
+// Leaf packages with clean source resolution are aliased to `src` so tests run
+// against source without a build. `@nesso-how/graph` keeps the default
+// resolution (its barrel uses built `.js` paths and pulls React) and relies on
+// `dist`, which `prepare` rebuilds on every install.
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': fromRoot('./src'),
+      '@nesso-how/types': fromRoot('./packages/types/src/index.ts'),
+      '@nesso-how/relation-types': fromRoot('./packages/relation-types/src/index.ts'),
+    },
+  },
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.{ts,tsx}', 'packages/*/src/**/*.test.{ts,tsx}'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['src/**/*.{ts,tsx}', 'packages/*/src/**/*.{ts,tsx}'],
+      exclude: ['**/*.test.{ts,tsx}', '**/*.d.ts'],
+    },
+  },
+})


### PR DESCRIPTION
## Summary

Adds the base of the testing pyramid: **Vitest** for fast, deterministic unit/integration tests on pure logic, plus a required `test` step in CI that gates PRs. Previously CI only verified that the code compiles and is formatted — nothing about correctness. This is the complement to e2e (#28): e2e is the slow/coarse top, this is the fast per-unit base both humans and agents can read.

Tests run against source (leaf packages aliased to `src`; `@nesso-how/graph` resolves to the `dist` that `prepare` rebuilds on install). Pure modules run in `node`; only store/React/DOM-touching files opt into jsdom per-file. The regression-prone workspace layer is tested as **real integration** — `manifest`, `paths`, `graphFiles`, the two-phase `sync`, and the store's `graph-management` slice run unmodified against an in-memory Tauri-fs boundary (`src/test/fakeTauriFs.ts`) plus `fake-indexeddb`, in both web and desktop modes.

Closes #29

## Changes

- **Tooling:** `vitest.config.ts` (env split, `@` + `@nesso-how/*` aliases, v8 coverage); `test` / `test:watch` / `test:coverage` scripts; dev deps `vitest`, `@vitest/coverage-v8`, `jsdom`, `fake-indexeddb`.
- **CI:** added `pnpm run test:coverage` as a required step in the `js` job (`.github/workflows/ci.yml`).
- **Packages:** excluded `*.test.ts` from `formats`/`types`/`graph` builds so tests never ship in `dist`.
- **Tests (98) across:** `@nesso-how/formats` (serialize/deserialize, validation, share-export), `@nesso-how/graph` geometry, `@nesso-how/types` (FSRS/display), `graphId`, `graphClipboard`, the `graph-editing` and `graph-management` store slices (web + desktop), and the workspace IO layer (`paths`, `manifest`, `graphFiles` naming/dedup, `sync` disk↔IDB merge: load, persist, disk-newer, external-delete, name-dedup; `desktop-sync` reload).
- **Shared test helper:** `src/test/fakeTauriFs.ts` — in-memory Tauri fs/path/core/dialog.
- **Docs/rules:** new `.rules/testing.md` (canonical) + Cursor/Claude wrappers; indexed in `AGENTS.md` and `.rules/maintenance.md`.

## Checklist

- [x] Branch name follows the naming convention
- [x] `## [Unreleased]` in `CHANGELOG.md` updated

## Testing

- `pnpm test` → 98 tests / 12 files passing.
- Full CI-equivalent run after rebasing onto `main`: `pnpm run format:check`, `pnpm run lint` (0 errors), `pnpm run build:mcp`, `pnpm run build` (incl. `tsc -b` type-checking the new `src` test files), `pnpm run license-headers:check` — all green.
- `pnpm run test:coverage` reports: `sync.ts` 97%, `manifest.ts` 100%, `desktop-sync.ts` 82%, `graphFiles.ts` 84%, `src/lib/workspace` 86% overall. No UI/Tauri/network is touched in this layer (those belong to #28).