### PR TITLE
chore(ci): cache apt packages in the rust job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,14 +119,20 @@ jobs:
       - name: Generate desktop icons from tile SVG
         run: pnpm run icons:desktop
 
-      - name: Install Tauri Linux system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            libgtk-3-dev \
-            librsvg2-dev \
+      # Cache the resolved .deb set instead of re-fetching ~62 MB from the Azure
+      # Ubuntu mirror every run: the download is the slowest part of this job and
+      # the mirror occasionally stalls for minutes on a single package. On a cache
+      # hit the packages restore from the Actions cache with no network. Bump
+      # `version` to invalidate the cache after changing the package list.
+      - name: Install Tauri Linux system dependencies (cached)
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: >-
+            libwebkit2gtk-4.1-dev
+            libgtk-3-dev
+            librsvg2-dev
             libayatana-appindicator3-dev
+          version: 1
 
       - run: cargo clippy --all-targets -- -D warnings
         working-directory: src-tauri


### PR DESCRIPTION
## Summary

The `rust` job in CI re-downloaded ~62 MB of Tauri Linux system dependencies from the Azure Ubuntu mirror on every run. The mirror occasionally stalls for minutes on a single package: a recent `main` run spent **~33 min** in the `Install Tauri Linux system dependencies` step while the actual `cargo` steps (clippy + check + test) took only **~26 s**. The "rust" check looked slow, but the bottleneck was purely apt download time, not Rust.

This caches the resolved `.deb` set so subsequent runs restore the packages from the Actions cache with no network, removing the dependency on the mirror's throughput.

## Changes

- Replace the manual `apt-get update && apt-get install -y …` step in the `rust` job with `awalsh128/cache-apt-pkgs-action@v1`, installing the same four packages (`libwebkit2gtk-4.1-dev`, `libgtk-3-dev`, `librsvg2-dev`, `libayatana-appindicator3-dev`).
- Add a `version` cache salt so the cache can be invalidated when the package list changes.
- Pin to a major tag (`@v1`), consistent with the other actions in the workflow (`@v6`, `@v2`, `@v5`).

## Checklist

- [x] Branch name follows the naming convention
- [ ] `## [Unreleased]` in `CHANGELOG.md` updated (CI-only change, not user-facing or release-note-worthy)

## Testing

- `prettier --check .github/workflows/ci.yml` → passes.
- YAML parses and the new step resolves to the expected `uses` / `packages` / `version`.
- The first CI run on this branch is a cache miss (full install, as before); the caching benefit is observable from the second run onward. Real validation of the action runs in CI itself, since `apt` cannot be exercised locally.