### PR TITLE
feat(telemetry): add opt-in crash and usage telemetry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,10 @@ jobs:
           # the matching public key lives in src-tauri/tauri.conf.json.
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # Opt-in telemetry SDK keys (EU region). Build succeeds without them.
+          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          VITE_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}
+          VITE_POSTHOG_HOST: https://eu.i.posthog.com
         with:
           projectPath: ./src-tauri
           tagName: v__VERSION__

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ docs/                 # Starlight docs site, published at nesso.how/docs
 - **Node** — a `ConceptNode` with `text` and FSRS fields (`stability`, `difficulty`, `reps`, `lapses`, `fsrsState`, `due`, `lastReview`, `lastRating`, `learningSteps`) for spaced repetition at runtime (`ts-fsrs`). FSRS is persisted in IndexedDB `reviewState`, not in graph JSON files.
 - **Edge** — a React Flow edge of type `'nesso'`, carrying `data.type: RelationTypeName` (semantic relation id; serialized as `GraphRelation.type` in graph JSON).
 - **Selection** — a single `{ kind: 'node' | 'edge', id }` (or `null`) tracked in the store (`src/store/types.ts`). Drives the Inspector and Socrates opening prompt.
-- **Settings** — `NessoSettings` in the store (dark mode, language, encoding, palette, AI endpoint fields, etc.). Applied via CSS custom properties on `<html>` where relevant.
+- **Settings** — `NessoSettings` in the store (dark mode, language, encoding, palette, AI endpoint fields, `telemetry` opt-in, etc.). Applied via CSS custom properties on `<html>` where relevant.
 
 ## Detailed rules index
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Added
+
+- **Opt-in telemetry:** Settings → **Privacy** adds a telemetry toggle (default off). When enabled, Nesso sends anonymous crash reports (Sentry) and coarse usage events (PostHog, EU region) — no graph content, Socrates chat, file paths, or API keys. Release builds pick up `VITE_SENTRY_DSN` / `VITE_POSTHOG_KEY` from repo secrets; local dev works without them.
+- **Feedback shortcut:** Status bar button opens GitHub issue chooser for user feedback.
+
+### Changed
+
+- **Docs — privacy:** Introduction page clarifies that graph data stays local and telemetry is opt-in.
+
 ## [0.1.0-alpha.35] - 2026-06-24
 
 ### Added

--- a/docs/src/content/docs/docs/introduction.md
+++ b/docs/src/content/docs/docs/introduction.md
@@ -29,7 +29,7 @@ AI is present, but with a constrained role. The AI mentor, Socrates, does not de
 
 **Constructivist by design.** Every feature is oriented around the learner doing cognitive work: drawing edges, labelling relations, writing definitions in their own words, self-rating recall. The system does not do this work for them.
 
-**Private by architecture.** In the web app, graphs are stored locally in your browser. In the desktop app, they are also saved as plain JSON files on your machine. The local AI mode runs entirely on your device; no data leaves it. Privacy is an implementation detail, not a policy promise.
+**Private by architecture.** In the web app, graphs are stored locally in your browser. In the desktop app, they are also saved as plain JSON files on your machine. Your graph content, definitions, and Socrates conversations never leave your device unless you connect a remote AI endpoint yourself. Optional telemetry (anonymous crash reports and aggregated usage events) is off by default and opt-in from Settings, Privacy; it never includes graph content, chat, or keys. Privacy is an implementation detail, not a policy promise.
 
 **Open by default.** The code is MIT-licensed. Data formats are documented and importable/exportable as plain JSON. The MCP server makes the graph vocabulary available to any compatible client. Technical work done here is intended to be useful beyond this application.
 

--- a/fallow-baselines/health.json
+++ b/fallow-baselines/health.json
@@ -1,10 +1,5 @@
 {
   "finding_counts": {
-    "packages/schema/src/index.ts": {
-      "crap_moderate": {
-        "count": 1
-      }
-    },
     "packages/graph/src/ConceptNodeBody.tsx": {
       "crap_high": {
         "count": 1
@@ -153,7 +148,10 @@
       }
     },
     "src/components/dialogs/SettingsDialog.tsx": {
-      "crap_moderate": {
+      "complexity_high": {
+        "count": 1
+      },
+      "crap_high": {
         "count": 1
       }
     },
@@ -220,8 +218,11 @@
       }
     },
     "src/components/layout/StatusBar.tsx": {
+      "crap_high": {
+        "count": 1
+      },
       "crap_moderate": {
-        "count": 2
+        "count": 1
       }
     },
     "src/components/layout/TopBar.tsx": {
@@ -237,10 +238,10 @@
         "count": 2
       },
       "crap_critical": {
-        "count": 2
+        "count": 3
       },
       "crap_high": {
-        "count": 3
+        "count": 2
       }
     },
     "src/components/mentor/ModelStatusBadge.tsx": {
@@ -366,10 +367,12 @@
       "complexity_moderate": {
         "count": 1
       },
-      "crap_high": {
-        "count": 1
-      },
       "crap_moderate": {
+        "count": 2
+      }
+    },
+    "src/telemetry/index.ts": {
+      "crap_high": {
         "count": 1
       }
     },
@@ -388,10 +391,11 @@
     "src/store/slices/graph-editing.ts:high impact",
     "src/lib/shortcuts.ts:complexity",
     "src/components/canvas/GraphCanvas.tsx:complexity",
+    "packages/graph/src/NessoGraph.tsx:complexity",
     "src/components/mentor/MentorPanel.tsx:complexity",
     "src/components/inspector/NodeInspector.tsx:complexity",
+    "src/components/review/ReviewMode.tsx:complexity",
     "src/components/inspector/InlineEdit.tsx:complexity",
-    "packages/graph/src/NessoGraph.tsx:complexity",
     "scripts/release.mjs:complexity"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -52,8 +52,9 @@
   "dependencies": {
     "@nesso-how/graph": "workspace:*",
     "@nesso-how/schema": "workspace:*",
-    "@nesso-how/vocab-learning": "workspace:*",
     "@nesso-how/theme": "workspace:*",
+    "@nesso-how/vocab-learning": "workspace:*",
+    "@sentry/react": "^10.60.0",
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-fs": "^2.5.0",
@@ -63,6 +64,7 @@
     "@xyflow/react": "^12.6.4",
     "html-to-image": "^1.11.13",
     "idb": "^8.0.3",
+    "posthog-js": "^1.393.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "ts-fsrs": "^5.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@nesso-how/vocab-learning':
         specifier: workspace:*
         version: link:packages/vocab-learning
+      '@sentry/react':
+        specifier: ^10.60.0
+        version: 10.60.0(react@18.3.1)
       '@tauri-apps/api':
         specifier: ^2.11.0
         version: 2.11.0
@@ -47,6 +50,9 @@ importers:
       idb:
         specifier: ^8.0.3
         version: 8.0.3
+      posthog-js:
+        specifier: ^1.393.3
+        version: 1.393.3
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1710,6 +1716,12 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@posthog/core@1.37.1':
+    resolution: {integrity: sha512-KRBuxF/XBm3tNpqWlXpWE82XxsYsJb0jSyEic14LMXMvqDv5iApK1jfV0+seikDb9SpPs3tPkWUfHdwaUtFBtQ==}
+
+  '@posthog/types@1.391.1':
+    resolution: {integrity: sha512-ASwd7Nf4pViqdYRYaNRyPYRVKWa1CcHUAUWR0XeQJLGdNnsWACBwe0sSieb/cHnKsRXjRwO/23KIY83lm/Ccpw==}
+
   '@promptbook/utils@0.69.5':
     resolution: {integrity: sha512-xm5Ti/Hp3o4xHrsK9Yy3MS6KbDxYbq485hDsFvxqaNA7equHLPdo8H8faTitTeb14QCDfLW4iwCxdVYu5sn6YQ==}
 
@@ -1860,6 +1872,36 @@ packages:
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@sentry/browser-utils@10.60.0':
+    resolution: {integrity: sha512-YhdPeMJnMaKVi5NQ2tD9RJ2AxU7cav5khmiMHFppmbP3I3Os2EHVaQjAVb6/ePAINr/d5mj5SxpnWmFX17iXsg==}
+    engines: {node: '>=18'}
+
+  '@sentry/browser@10.60.0':
+    resolution: {integrity: sha512-20vzPKGrmupJPCaWd+soCOLkZRwKZxt0AVF4XGPNoGp7D7wVPRlHf+FWwVMx+rRRkahKupFefM2D9YoiUiBeag==}
+    engines: {node: '>=18'}
+
+  '@sentry/core@10.60.0':
+    resolution: {integrity: sha512-szN7ccOJAEaLb1BBQzCQhABGMTJmKNUk0G2sc7rWhajeXoZoMKIbNkI9RvJrFuV69cbad/d/BKGBjbpJhySAzw==}
+    engines: {node: '>=18'}
+
+  '@sentry/feedback@10.60.0':
+    resolution: {integrity: sha512-RcGUgaI8yrIXunhNLpdNLsBUJIDvnEGDRmFhC5v0oMltoGtovrIqrEhPXEiSWQvNB0x4q33ejkLeJRJoSDOp2w==}
+    engines: {node: '>=18'}
+
+  '@sentry/react@10.60.0':
+    resolution: {integrity: sha512-ALRIDOj7T1Vk9t9IyI12Tq2t3MKoV2F/mKn140AiUBk3WzQhq2gXQUFpcsaDYA2FBsrYoYc6qdqrny6mMbA0Xg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.14.0 || 17.x || 18.x || 19.x
+
+  '@sentry/replay-canvas@10.60.0':
+    resolution: {integrity: sha512-mYyQRJbhRRaqUkRvkJZyqt9AWdomh4108LOAph1YJvV1jW7tKYPPFNAUveJd7YkYCyhUOtekN0DKNJveK802qA==}
+    engines: {node: '>=18'}
+
+  '@sentry/replay@10.60.0':
+    resolution: {integrity: sha512-j+w774BP1p+v/ga1hJAJSn0cXgTiB2VWwQCAxukF7AEXscny/OCXzTTsaPxdovw9kDHI641vKV+/yixLV2nKIQ==}
+    engines: {node: '>=18'}
 
   '@shikijs/core@4.2.0':
     resolution: {integrity: sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==}
@@ -2123,6 +2165,9 @@ packages:
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -2663,6 +2708,9 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
@@ -2854,6 +2902,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -3129,6 +3180,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -4211,6 +4265,12 @@ packages:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-js@1.393.3:
+    resolution: {integrity: sha512-EpRSk7TxEpy045AQiRSFPHmN+1y7NzIJoeieruPfZhDy9bp9OftEzXxDZzN7FfP7ue9N98816nMlqqXqf8uSSg==}
+
+  preact@10.29.2:
+    resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
+
   prettier@3.8.3:
     resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
@@ -5138,6 +5198,9 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
   webdriver@9.29.0:
     resolution: {integrity: sha512-RzD+aleJeVqG4aGhp4QGQNriaBYnBV0pyC+v1AAZKoxBK+nb0W5iVWTwkTFGGMDdJGWR7s+M8Ozm6lXihpCBww==}
@@ -6641,6 +6704,12 @@ snapshots:
     dependencies:
       playwright: 1.61.0
 
+  '@posthog/core@1.37.1':
+    dependencies:
+      '@posthog/types': 1.391.1
+
+  '@posthog/types@1.391.1': {}
+
   '@promptbook/utils@0.69.5':
     dependencies:
       spacetrim: 0.11.59
@@ -6748,6 +6817,40 @@ snapshots:
     optional: true
 
   '@sec-ant/readable-stream@0.4.1': {}
+
+  '@sentry/browser-utils@10.60.0':
+    dependencies:
+      '@sentry/core': 10.60.0
+
+  '@sentry/browser@10.60.0':
+    dependencies:
+      '@sentry/browser-utils': 10.60.0
+      '@sentry/core': 10.60.0
+      '@sentry/feedback': 10.60.0
+      '@sentry/replay': 10.60.0
+      '@sentry/replay-canvas': 10.60.0
+
+  '@sentry/core@10.60.0': {}
+
+  '@sentry/feedback@10.60.0':
+    dependencies:
+      '@sentry/core': 10.60.0
+
+  '@sentry/react@10.60.0(react@18.3.1)':
+    dependencies:
+      '@sentry/browser': 10.60.0
+      '@sentry/core': 10.60.0
+      react: 18.3.1
+
+  '@sentry/replay-canvas@10.60.0':
+    dependencies:
+      '@sentry/core': 10.60.0
+      '@sentry/replay': 10.60.0
+
+  '@sentry/replay@10.60.0':
+    dependencies:
+      '@sentry/browser-utils': 10.60.0
+      '@sentry/core': 10.60.0
 
   '@shikijs/core@4.2.0':
     dependencies:
@@ -7054,6 +7157,9 @@ snapshots:
   '@types/sinonjs__fake-timers@8.1.5': {}
 
   '@types/stack-utils@2.0.3': {}
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/unist@2.0.11': {}
 
@@ -7807,6 +7913,8 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  core-js@3.49.0: {}
+
   core-util-is@1.0.3: {}
 
   crc-32@1.2.2: {}
@@ -7992,6 +8100,10 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.4.11:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:
@@ -8373,6 +8485,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.4.8: {}
 
   figures@6.1.0:
     dependencies:
@@ -9886,6 +10000,19 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  posthog-js@1.393.3:
+    dependencies:
+      '@posthog/core': 1.37.1
+      '@posthog/types': 1.391.1
+      core-js: 3.49.0
+      dompurify: 3.4.11
+      fflate: 0.4.8
+      preact: 10.29.2
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+
+  preact@10.29.2: {}
+
   prettier@3.8.3: {}
 
   pretty-format@30.4.1:
@@ -10864,6 +10991,8 @@ snapshots:
   weapon-regex@1.3.6: {}
 
   web-namespaces@2.0.1: {}
+
+  web-vitals@5.3.0: {}
 
   webdriver@9.29.0:
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,9 @@ import { resolveShortcut } from './lib/shortcuts'
 import { computeSelectionPan } from './lib/selectionPan'
 import { computeFitViewport, fitCanvasSize } from './lib/fitGraphViewport'
 import { getSeedInitialFitZoom } from './data/seedGraph'
+import { APP_VERSION } from './data/appInfo'
+import { isDesktop } from './lib/isDesktop'
+import { initTelemetry, shutdownTelemetry, track } from './telemetry'
 
 function AppInner() {
   const [showReview, setShowReview] = useState(false)
@@ -50,6 +53,7 @@ function AppInner() {
   const [showAbout, setShowAbout] = useState(false)
 
   const settings = useGraphStore((s) => s.settings)
+  const telemetry = settings.telemetry
   const addNode = useGraphStore((s) => s.addNode)
   const selected = useGraphStore((s) => s.selected)
   const setSelected = useGraphStore((s) => s.setSelected)
@@ -78,6 +82,30 @@ function AppInner() {
 
   useAutoSave()
   useGraphFileWatch()
+
+  useEffect(() => {
+    if (telemetry) void initTelemetry(true)
+    else void shutdownTelemetry()
+  }, [telemetry])
+
+  const appStartedRef = useRef(false)
+  useEffect(() => {
+    if (appStartedRef.current) return
+    appStartedRef.current = true
+    track({
+      name: 'app_started',
+      props: {
+        version: APP_VERSION,
+        platform: isDesktop() ? 'desktop' : 'web',
+        language: useGraphStore.getState().settings.language,
+      },
+    })
+  }, [])
+
+  const openReview = useCallback(() => {
+    track({ name: 'review_session_started' })
+    setShowReview(true)
+  }, [])
 
   const [sidebarPanelWidth, setSidebarPanelWidth] = useState(readSidebarWidth)
   useEffect(() => {
@@ -253,6 +281,7 @@ function AppInner() {
     // Prevent the viewport-restore effect from overriding our setCenter below.
     viewportRestoredFor.current = useGraphStore.getState().currentGraphId
     addNode(x, y)
+    track({ name: 'node_created' })
     setCenter(nodeCx, nodeCy, { zoom: Math.max(getViewport().zoom, 1), duration: 300 })
   }, [
     addNode,
@@ -398,7 +427,7 @@ function AppInner() {
           break
         }
         case 'open-review':
-          if (useGraphStore.getState().settings.reviewEnabled) setShowReview(true)
+          if (useGraphStore.getState().settings.reviewEnabled) openReview()
           break
         case 'add-concept':
           handleAddConcept()
@@ -423,6 +452,7 @@ function AppInner() {
     deleteSelection,
     requestEditNode,
     handleAddConcept,
+    openReview,
     fitView,
     anyModalOpen,
   ])
@@ -452,7 +482,7 @@ function AppInner() {
         sidebarCollapsed={sidebarCollapsed}
         sidebarWidth={sidebarWidth}
         onExpandSidebar={() => setSidebarCollapsed(false)}
-        onReview={() => setShowReview(true)}
+        onReview={openReview}
         onRelationTypes={() => setShowRelationTypes((s) => !s)}
         onShortcuts={() => setShowShortcuts((s) => !s)}
         onAbout={() => setShowAbout(true)}

--- a/src/components/canvas/GraphCanvas.tsx
+++ b/src/components/canvas/GraphCanvas.tsx
@@ -18,6 +18,7 @@ import { useGraphContextMenu } from './useGraphContextMenu'
 import { useConnectRelation } from './useConnectRelation'
 import { RelationPicker } from '@/components/ui/RelationPicker'
 import { useT } from '@/i18n'
+import { track } from '@/telemetry'
 import { useGraphStore } from '@/store'
 import { computeFitViewport } from '@/lib/fitGraphViewport'
 import { styleEdges } from '@/lib/styleEdges'
@@ -142,6 +143,7 @@ export function GraphCanvas({
       const { x, y } = screenToFlowPosition({ x: event.clientX, y: event.clientY })
       const pos = newConceptTopLeftAtFlowCenter(x, y)
       addNode(pos.x, pos.y)
+      track({ name: 'node_created' })
     },
     [addNode, screenToFlowPosition],
   )

--- a/src/components/canvas/GraphContextMenu.tsx
+++ b/src/components/canvas/GraphContextMenu.tsx
@@ -5,6 +5,7 @@ import { useT } from '@/i18n'
 import { newConceptTopLeftAtFlowCenter } from '@/data/newConceptLayout'
 import { focusFlowNodes } from '@/lib/focusFlowSelection'
 import { Icon } from '@/components/ui/icons'
+import { track } from '@/telemetry'
 
 export type ContextMenuState = {
   x: number
@@ -209,6 +210,7 @@ export function GraphContextMenu({
         onClick: () => {
           const p = newConceptTopLeftAtFlowCenter(menu.flowX ?? 0, menu.flowY ?? 0)
           addNode(p.x, p.y)
+          track({ name: 'node_created' })
         },
       },
       'sep',

--- a/src/components/canvas/useConnectRelation.ts
+++ b/src/components/canvas/useConnectRelation.ts
@@ -3,6 +3,7 @@ import { useCallback, useRef, useState } from 'react'
 import type { OnConnect, OnConnectStart, OnConnectEnd } from '@xyflow/react'
 import { useGraphStore } from '@/store'
 import type { RelationTypeName } from '@/types/graph'
+import { track } from '@/telemetry'
 
 export interface PendingConnection {
   source: string
@@ -49,6 +50,7 @@ export function useConnectRelation() {
     (type: RelationTypeName) => {
       if (!pendingConn) return
       addEdge(pendingConn.source, pendingConn.target, type)
+      track({ name: 'edge_created', props: { relation_type: type } })
       setPendingConn(null)
     },
     [pendingConn, addEdge],

--- a/src/components/dialogs/SettingsDialog.tsx
+++ b/src/components/dialogs/SettingsDialog.tsx
@@ -20,8 +20,8 @@ const OLLAMA_PRESETS = [
   { id: 'qwen3:8b', note: 'newest · best reasoning' },
 ] as const
 
-type Tab = 'appearance' | 'learning' | 'ai'
-const ALL_TABS = ['appearance', 'learning', 'ai'] as const
+type Tab = 'appearance' | 'learning' | 'ai' | 'privacy'
+const ALL_TABS = ['appearance', 'learning', 'ai', 'privacy'] as const
 
 const LANGUAGES: { id: Language; label: string }[] = [
   { id: 'en', label: 'English' },
@@ -465,6 +465,39 @@ export function SettingsDialog({ open, onClose }: Props) {
             )}
 
             {tab === 'learning' && <LearningSettings />}
+
+            {tab === 'privacy' && (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+                <SettingsFormRow divider={false} label={t.settings.privacy.telemetry}>
+                  <Switch value={settings.telemetry} onChange={(v) => setSetting('telemetry', v)} />
+                </SettingsFormRow>
+                <small
+                  style={{
+                    display: 'block',
+                    fontSize: '11px',
+                    fontWeight: 400,
+                    lineHeight: 1.5,
+                    fontFamily: 'var(--font-sans)',
+                    color: 'var(--ink-4)',
+                    marginTop: -8,
+                  }}
+                >
+                  {t.settings.privacy.telemetryDesc}
+                </small>
+                <small
+                  style={{
+                    display: 'block',
+                    fontSize: '11px',
+                    fontWeight: 400,
+                    lineHeight: 1.5,
+                    fontFamily: 'var(--font-sans)',
+                    color: 'var(--ink-4)',
+                  }}
+                >
+                  {t.settings.privacy.telemetryDetails}
+                </small>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 import { useState, useRef, useEffect } from 'react'
 import { useGraphStore } from '@/store'
+import { track } from '@/telemetry'
 import { useHorizontalResize } from '@/hooks/useHorizontalResize'
 import { useT } from '@/i18n'
 import { SegmentedControl } from '@/components/ui/SegmentedControl'
@@ -110,6 +111,7 @@ export function Sidebar({
 
   const handleNew = async () => {
     const id = await createGraph(t.sidebar.untitled)
+    track({ name: 'graph_created' })
     setTimeout(() => {
       const g = useGraphStore.getState().graphList.find((x) => x.id === id)
       if (g) startRename(id, g.name)

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -4,6 +4,8 @@ import { useReactFlow, useStore as useFlowStore } from '@xyflow/react'
 import { useGraphStore } from '@/store'
 import { useT } from '@/i18n'
 import { SocratesGlyph } from '@/components/mentor/SocratesGlyph'
+import { FEEDBACK_URL, openExternal } from '@/data/appInfo'
+import { track } from '@/telemetry'
 
 export const STATUS_BAR_HEIGHT_PX = 30
 
@@ -12,7 +14,7 @@ interface Props {
   onFit: () => void
 }
 
-type IconName = 'undo' | 'redo' | 'minus' | 'plus' | 'fit'
+type IconName = 'undo' | 'redo' | 'minus' | 'plus' | 'fit' | 'feedback'
 
 function StatusIcon({ name }: { name: IconName }) {
   const p = {
@@ -56,6 +58,12 @@ function StatusIcon({ name }: { name: IconName }) {
       return (
         <svg {...p}>
           <path d="M3 6V3h3M13 6V3h-3M3 10v3h3M13 10v3h-3" />
+        </svg>
+      )
+    case 'feedback':
+      return (
+        <svg {...p}>
+          <path d="M3 4.5h10a1 1 0 0 1 1 1v5a1 1 0 0 1-1 1H6l-3 2.5V5.5a1 1 0 0 1 1-1z" />
         </svg>
       )
   }
@@ -131,7 +139,10 @@ function SocratesEntry() {
     <button
       type="button"
       title={t.statusBar.socratesTitle}
-      onClick={() => setOpen(!open)}
+      onClick={() => {
+        if (!open) track({ name: 'mentor_session_started' })
+        setOpen(!open)
+      }}
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
       style={{
@@ -220,8 +231,15 @@ export function StatusBar({ sidebarWidth, onFit }: Props) {
         </span>
       </div>
 
-      {/* Right — history + viewport controls */}
+      {/* Right — feedback + history + viewport controls */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-1)', flexShrink: 0 }}>
+        <StatusBtn
+          onClick={() => void openExternal(FEEDBACK_URL)}
+          title={t.statusBar.feedbackTitle}
+        >
+          <StatusIcon name="feedback" />
+        </StatusBtn>
+        <span style={sep} />
         <StatusBtn onClick={undo} disabled={!canUndo} title={t.statusBar.undoTitle}>
           <StatusIcon name="undo" />
         </StatusBtn>

--- a/src/components/mentor/MentorPanel.tsx
+++ b/src/components/mentor/MentorPanel.tsx
@@ -11,10 +11,16 @@ import { CloseButton } from '@/components/ui/CloseButton'
 import { STATUS_BAR_HEIGHT_PX } from '@/components/layout/StatusBar'
 import { ThinkingIndicator } from './ThinkingIndicator'
 import { renderWithEmphasis } from './emphasis'
+import { track } from '@/telemetry'
 
 interface Message {
   role: 'user' | 'mentor'
   text: string
+}
+
+/** Coarse failure category for telemetry: a fetch network/CORS failure throws TypeError; an HTTP error does not. */
+function mentorFailureReason(err: unknown): 'network' | 'response' {
+  return err instanceof TypeError ? 'network' : 'response'
 }
 
 function appendToLastMentor(history: Message[], delta: string): Message[] {
@@ -249,8 +255,11 @@ export function MentorPanel({ leftInset, rightInset }: { leftInset: number; righ
           setHistory([{ role: 'mentor', text: full || '…' }])
         }
       })
-      .catch(() => {
-        if (!controller.signal.aborted) setHistory([{ role: 'mentor', text: t.mentor.errorRetry }])
+      .catch((err) => {
+        if (!controller.signal.aborted) {
+          setHistory([{ role: 'mentor', text: t.mentor.errorRetry }])
+          track({ name: 'mentor_request_failed', props: { reason: mentorFailureReason(err) } })
+        }
       })
       .finally(() => {
         if (!controller.signal.aborted) {
@@ -289,6 +298,7 @@ export function MentorPanel({ leftInset, rightInset }: { leftInset: number; righ
     setHistory(next)
     setDraft('')
     setThinking(true)
+    track({ name: 'mentor_message_sent' })
     requestAnimationFrame(() => {
       const el = scrollRef.current
       if (el) el.scrollTop = el.scrollHeight
@@ -315,9 +325,11 @@ export function MentorPanel({ leftInset, rightInset }: { leftInset: number; righ
       if (!controller.signal.aborted && !started) {
         setHistory((h) => [...h, { role: 'mentor', text: full || '…' }])
       }
-    } catch {
+      if (!controller.signal.aborted) track({ name: 'mentor_response_received' })
+    } catch (err) {
       if (!controller.signal.aborted) {
         setHistory((h) => [...h, { role: 'mentor', text: t.mentor.errorRetrySlow }])
+        track({ name: 'mentor_request_failed', props: { reason: mentorFailureReason(err) } })
       }
     } finally {
       if (!controller.signal.aborted) setStreaming(false)

--- a/src/components/review/ReviewMode.tsx
+++ b/src/components/review/ReviewMode.tsx
@@ -9,8 +9,16 @@ import { ratingColor } from '@nesso-how/graph'
 import { useT } from '@/i18n'
 import { CloseButton } from '@/components/ui/CloseButton'
 import { ModalOverlay } from '@/components/ui/ModalOverlay'
+import { track } from '@/telemetry'
 
 const RATINGS = [Rating.Again, Rating.Hard, Rating.Good, Rating.Easy] as const
+
+const RATING_EVENT_NAMES = {
+  [Rating.Again]: 'again',
+  [Rating.Hard]: 'hard',
+  [Rating.Good]: 'good',
+  [Rating.Easy]: 'easy',
+} as const satisfies Record<(typeof RATINGS)[number], 'again' | 'hard' | 'good' | 'easy'>
 
 function formatInterval(ms: number): string {
   if (ms < 60_000) return '< 1m'
@@ -156,6 +164,10 @@ export function ReviewMode({ open, onClose }: Props) {
         lastReview: now.getTime(),
         lastRating: rating,
         learningSteps: card.learning_steps,
+      })
+      track({
+        name: 'review_card_rated',
+        props: { rating: RATING_EVENT_NAMES[rating as (typeof RATINGS)[number]] },
       })
     }
     setRevealed(false)

--- a/src/data/appInfo.ts
+++ b/src/data/appInfo.ts
@@ -4,6 +4,7 @@ import { isDesktop } from '@/lib/isDesktop'
 export const APP_VERSION = __APP_VERSION__
 
 export const REPO_URL = 'https://github.com/nesso-how/nesso'
+export const FEEDBACK_URL = `${REPO_URL}/issues/new/choose`
 export const WEBSITE_URL = 'https://nesso.how'
 export const DOCS_URL = 'https://nesso.how/docs/introduction'
 export const CHANGELOG_URL = `${REPO_URL}/blob/main/CHANGELOG.md`

--- a/src/hooks/useDesktopMenu.ts
+++ b/src/hooks/useDesktopMenu.ts
@@ -7,7 +7,7 @@ import { isDesktop } from '@/lib/isDesktop'
 import { applyDesktopMenu } from '@/lib/desktopMenu'
 import { exportGraphJson, exportGraphPng, importGraphFile } from '@/lib/graphIO'
 import { focusFlowNodes } from '@/lib/focusFlowSelection'
-import { openExternal, DOCS_URL, WEBSITE_URL, REPO_URL } from '@/data/appInfo'
+import { openExternal, DOCS_URL, WEBSITE_URL, FEEDBACK_URL } from '@/data/appInfo'
 
 interface DesktopMenuHandlers {
   onSettings: () => void
@@ -79,7 +79,7 @@ export function useDesktopMenu(handlers: DesktopMenuHandlers): void {
 
       await on('docs', () => void openExternal(DOCS_URL))
       await on('website', () => void openExternal(WEBSITE_URL))
-      await on('report-issue', () => void openExternal(`${REPO_URL}/issues`))
+      await on('report-issue', () => void openExternal(FEEDBACK_URL))
 
       if (cancelled) unlistens.forEach((u) => u())
     })()

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -25,6 +25,7 @@ const en = {
       appearance: 'Appearance',
       ai: 'AI',
       learning: 'Learning',
+      privacy: 'Privacy',
     },
     appearance: {
       theme: 'Theme',
@@ -64,6 +65,13 @@ const en = {
         corsBlocked: 'CORS blocked — set',
         unreachable: 'API unreachable',
       },
+    },
+    privacy: {
+      telemetry: 'Telemetry',
+      telemetryDesc:
+        'When enabled, Nesso sends anonymous crash reports and aggregated usage events to help improve the app. No graph content, chat, or API keys are ever sent. No IP address is collected.',
+      telemetryDetails:
+        'What we collect: crash stack traces and coarse usage signals (e.g. a node was created). What we never collect: node text, graph structure, Socrates conversations, file paths, or API keys. Legal basis: your consent. Revoke anytime with this toggle.',
     },
     learning: {
       review: 'Review',
@@ -260,6 +268,7 @@ const en = {
     zoomOutTitle: 'Zoom out',
     zoomInTitle: 'Zoom in',
     fitTitle: 'Center / fit (F)',
+    feedbackTitle: 'Send feedback',
   },
   contextMenu: {
     copy: 'Copy',

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -25,6 +25,7 @@ const it: typeof en = {
       appearance: 'Aspetto',
       ai: 'AI',
       learning: 'Apprendimento',
+      privacy: 'Privacy',
     },
     appearance: {
       theme: 'Tema',
@@ -64,6 +65,13 @@ const it: typeof en = {
         corsBlocked: 'CORS bloccato — imposta',
         unreachable: 'API non raggiungibile',
       },
+    },
+    privacy: {
+      telemetry: 'Telemetria',
+      telemetryDesc:
+        "Quando attiva, Nesso invia report di crash anonimi e eventi d'uso aggregati per migliorare l'app. Nessun contenuto del grafo, chat o chiavi API viene mai inviato. Nessun indirizzo IP viene raccolto.",
+      telemetryDetails:
+        "Cosa raccogliamo: stack trace di crash e segnali d'uso grossolani (es. un nodo creato). Cosa non raccogliamo mai: testi dei nodi, struttura del grafo, conversazioni con Socrate, percorsi file o chiavi API. Base giuridica: il tuo consenso. Revoca in qualsiasi momento con questo interruttore.",
     },
     learning: {
       review: 'Revisione',
@@ -262,6 +270,7 @@ const it: typeof en = {
     zoomOutTitle: 'Riduci zoom',
     zoomInTitle: 'Aumenta zoom',
     fitTitle: 'Centra / adatta (F)',
+    feedbackTitle: 'Invia feedback',
   },
   contextMenu: {
     copy: 'Copia',

--- a/src/lib/graphIO.ts
+++ b/src/lib/graphIO.ts
@@ -8,6 +8,7 @@ import { useGraphStore } from '@/store'
 import { getT } from '@/i18n'
 import { toast } from '@/components/ui/toast'
 import { exportShareGraphJson } from '@/lib/saveJsonFile'
+import { track } from '@/telemetry'
 
 /** Serializes the active graph to JSON and triggers a file download / save dialog. */
 export async function exportGraphJson(): Promise<void> {
@@ -17,6 +18,7 @@ export async function exportGraphJson(): Promise<void> {
   const filename = `${name}.json`
   const payload = serialize(graphToDocument({ name, nodes, edges, display: graphDisplay }))
   await exportShareGraphJson(filename, payload)
+  track({ name: 'graph_exported', props: { format: 'json' } })
 }
 
 /** Renders the current React Flow viewport to a PNG and downloads it. */
@@ -67,6 +69,7 @@ export async function exportGraphPng(): Promise<void> {
     a.href = dataUrl
     a.download = `${name}.png`
     a.click()
+    track({ name: 'graph_exported', props: { format: 'png' } })
   } catch {
     /* export cancelled or unsupported */
   }
@@ -85,6 +88,7 @@ export function importGraphFile(): void {
       const name = doc.name?.trim() || file.name.replace(/\.json$/i, '')
       const { nodes, edges, display } = await documentToGraph(doc, '')
       await useGraphStore.getState().importGraph(name, nodes, edges, display, doc.id)
+      track({ name: 'graph_imported' })
     } catch {
       toast.error(getT().graphIO.importError.replace('{name}', file.name))
     }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,9 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App'
+import { initTelemetry, readTelemetryConsent } from '@/telemetry'
+
+void initTelemetry(readTelemetryConsent())
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/store/slices/settings.ts
+++ b/src/store/slices/settings.ts
@@ -35,6 +35,7 @@ export const createSettingsSlice: StateCreator<GraphState, [], [], SettingsSlice
     inspectorRelationsOpen: true,
     knownProjects: [],
     activeProjectPath: null,
+    telemetry: false,
   },
   graphDisplay: defaultGraphDisplay(),
 

--- a/src/telemetry/consent.test.ts
+++ b/src/telemetry/consent.test.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { ZUSTAND_PERSIST_KEY } from '@/data/storageKeys'
+import { readTelemetryConsent } from './consent'
+
+describe('readTelemetryConsent', () => {
+  afterEach(() => {
+    localStorage.removeItem(ZUSTAND_PERSIST_KEY)
+  })
+
+  it('returns false when nothing is persisted', () => {
+    expect(readTelemetryConsent()).toBe(false)
+  })
+
+  it('returns false when telemetry is absent or false', () => {
+    localStorage.setItem(
+      ZUSTAND_PERSIST_KEY,
+      JSON.stringify({ state: { settings: { telemetry: false } } }),
+    )
+    expect(readTelemetryConsent()).toBe(false)
+  })
+
+  it('returns true only when telemetry is explicitly true', () => {
+    localStorage.setItem(
+      ZUSTAND_PERSIST_KEY,
+      JSON.stringify({ state: { settings: { telemetry: true } } }),
+    )
+    expect(readTelemetryConsent()).toBe(true)
+  })
+
+  it('returns false on malformed JSON', () => {
+    localStorage.setItem(ZUSTAND_PERSIST_KEY, '{not json')
+    expect(readTelemetryConsent()).toBe(false)
+  })
+})

--- a/src/telemetry/consent.ts
+++ b/src/telemetry/consent.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+import { ZUSTAND_PERSIST_KEY } from '@/data/storageKeys'
+
+/** Read persisted opt-in without importing the store (safe at boot). */
+export function readTelemetryConsent(): boolean {
+  try {
+    const raw = localStorage.getItem(ZUSTAND_PERSIST_KEY)
+    if (!raw) return false
+    const parsed = JSON.parse(raw) as { state?: { settings?: { telemetry?: boolean } } }
+    return parsed.state?.settings?.telemetry === true
+  } catch {
+    return false
+  }
+}

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+import { APP_VERSION } from '@/data/appInfo'
+import type { RelationTypeName } from '@/types/graph'
+
+export { readTelemetryConsent } from './consent'
+
+type TelemetryEvent =
+  | {
+      name: 'app_started'
+      props: { version: string; platform: 'desktop' | 'web'; language: string }
+    }
+  | { name: 'node_created' }
+  | { name: 'edge_created'; props: { relation_type: RelationTypeName } }
+  | { name: 'mentor_session_started' }
+  | { name: 'mentor_message_sent' }
+  | { name: 'mentor_response_received' }
+  | { name: 'mentor_request_failed'; props: { reason: 'network' | 'response' } }
+  | { name: 'review_session_started' }
+  | { name: 'review_card_rated'; props: { rating: 'again' | 'hard' | 'good' | 'easy' } }
+  | { name: 'graph_created' }
+  | { name: 'graph_imported' }
+  | { name: 'graph_exported'; props: { format: 'json' | 'png' } }
+
+let active = false
+let initializing = false
+let sentryLoaded = false
+let posthogClient: typeof import('posthog-js').default | null = null
+const pending: TelemetryEvent[] = []
+
+export async function initTelemetry(enabled: boolean): Promise<void> {
+  if (!enabled) {
+    await shutdownTelemetry()
+    return
+  }
+  if (active || initializing) return
+  initializing = true
+
+  const sentryDsn = import.meta.env.VITE_SENTRY_DSN
+  const posthogKey = import.meta.env.VITE_POSTHOG_KEY
+
+  if (sentryDsn) await initSentry(sentryDsn)
+  if (posthogKey) await initPostHog(posthogKey)
+
+  active = Boolean(sentryDsn || posthogKey)
+  initializing = false
+  flush()
+}
+
+async function initSentry(dsn: string): Promise<void> {
+  const Sentry = await import('@sentry/react')
+  sentryLoaded = true
+  Sentry.init({
+    dsn,
+    environment: import.meta.env.MODE,
+    release: `nesso@${APP_VERSION}`,
+    enabled: true,
+    sendDefaultPii: false,
+    integrations: (defaults) => [
+      ...defaults.filter((i) => i.name !== 'CultureContext' && i.name !== 'Breadcrumbs'),
+      Sentry.breadcrumbsIntegration({ console: false, dom: false }),
+    ],
+    maxBreadcrumbs: 20,
+    tracesSampleRate: 0,
+    beforeBreadcrumb: (crumb) =>
+      crumb.category === 'navigation' || crumb.category === 'fetch' ? null : crumb,
+    beforeSend: (event) => {
+      if (event.request) {
+        event.request.url = undefined
+        event.request.headers = undefined
+        event.request.query_string = undefined
+        event.request.data = undefined
+      }
+      delete event.user
+      return event
+    },
+  })
+}
+
+async function initPostHog(key: string): Promise<void> {
+  const posthog = (await import('posthog-js')).default
+  posthog.init(key, {
+    api_host: import.meta.env.VITE_POSTHOG_HOST ?? 'https://eu.i.posthog.com',
+    autocapture: false,
+    capture_pageview: false,
+    capture_pageleave: false,
+    disable_session_recording: true,
+    persistence: 'localStorage',
+    person_profiles: 'identified_only',
+    property_denylist: [
+      '$current_url',
+      '$pathname',
+      '$referrer',
+      '$referring_domain',
+      '$session_entry_url',
+      '$session_entry_pathname',
+      '$session_entry_referrer',
+      '$session_entry_referring_domain',
+      '$timezone',
+      '$timezone_offset',
+      '$raw_user_agent',
+      '$browser_language',
+      '$browser_language_prefix',
+      '$screen_height',
+      '$screen_width',
+      '$viewport_height',
+      '$viewport_width',
+    ],
+    opt_out_capturing_by_default: true,
+    sanitize_properties: (props) => {
+      delete props.$current_url
+      delete props.$pathname
+      delete props.$session_entry_url
+      return props
+    },
+  })
+  posthog.opt_in_capturing()
+  posthogClient = posthog
+}
+
+export async function shutdownTelemetry(): Promise<void> {
+  pending.length = 0
+  if (posthogClient) {
+    posthogClient.opt_out_capturing()
+    posthogClient = null
+  }
+  if (sentryLoaded) {
+    const Sentry = await import('@sentry/react')
+    await Sentry.close()
+    sentryLoaded = false
+  }
+  active = false
+}
+
+export function track(event: TelemetryEvent): void {
+  if (posthogClient) {
+    capture(event)
+  } else if (initializing) {
+    pending.push(event)
+  }
+}
+
+function flush(): void {
+  if (posthogClient) for (const event of pending) capture(event)
+  pending.length = 0
+}
+
+function capture(event: TelemetryEvent): void {
+  if (!posthogClient) return
+  if ('props' in event) posthogClient.capture(event.name, event.props)
+  else posthogClient.capture(event.name)
+}

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -27,6 +27,8 @@ export interface NessoSettings {
   knownProjects: string[]
   /** Desktop: absolute path of the active project folder; null until resolved at startup. */
   activeProjectPath: string | null
+  /** Opt-in: anonymous crash reports (Sentry) and usage events (PostHog). Default false. */
+  telemetry: boolean
 }
 
 export function nodeToCard(data: ConceptNodeData): Card {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -29,3 +29,13 @@ declare module '*.css' {
 }
 
 declare const __APP_VERSION__: string
+
+interface ImportMetaEnv {
+  readonly VITE_SENTRY_DSN?: string
+  readonly VITE_POSTHOG_KEY?: string
+  readonly VITE_POSTHOG_HOST?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
## Summary

Adds opt-in telemetry and an in-app feedback channel for the alpha (#78). Crash reporting (Sentry) and coarse usage events (PostHog, EU region) are **off by default** and controlled from **Settings → Privacy**. No graph content, Socrates conversations, file paths, or API keys are ever sent.

Closes #78

## Changes

- Add `src/telemetry/` module: lazy Sentry + PostHog init, consent read at boot, typed event tracking
- Add `settings.telemetry` toggle with Privacy tab copy (EN/IT)
- Instrument core flows: app start, graph create/import/export, node/edge create, mentor session, review ratings
- Add status bar feedback button linking to GitHub issue chooser
- Wire `VITE_SENTRY_DSN` / `VITE_POSTHOG_KEY` into release workflow
- Update docs introduction privacy section and fallow health baseline

## Checklist

- [x] Branch name follows the naming convention
- [x] `## [Unreleased]` in `CHANGELOG.md` updated

## Testing

- `pnpm test` — consent unit tests pass
- Manual: toggle telemetry in Settings → Privacy; verify no network calls when off, PostHog events when on (with `.env` keys)
- Manual: feedback button opens GitHub issue chooser