### PR TITLE
docs(rules): add compatibility stance and idempotent IDB bootstrap

### DIFF
--- a/.claude/rules/compatibility.md
+++ b/.claude/rules/compatibility.md
@@ -1,0 +1,12 @@
+---
+paths:
+  - packages/schema/**
+  - packages/vocab-learning/**
+  - src/lib/workspace/**
+  - src/lib/graphDocumentMapping.ts
+  - src/lib/graphMapping.ts
+  - src/store/**
+  - src/data/conceptNodes.ts
+---
+
+@../../.rules/compatibility.md

--- a/.cursor/rules/compatibility.mdc
+++ b/.cursor/rules/compatibility.mdc
@@ -1,0 +1,16 @@
+---
+description: Persisted-data compatibility — envelope/vocabulary migration ladders and load boundaries
+globs:
+  - packages/schema/**
+  - packages/vocab-learning/**
+  - src/lib/workspace/**
+  - src/lib/graphDocumentMapping.ts
+  - src/lib/graphMapping.ts
+  - src/store/**
+  - src/data/conceptNodes.ts
+alwaysApply: false
+---
+
+Canonical content lives in [`.rules/compatibility.md`](../../.rules/compatibility.md). Edit that file, not this wrapper.
+
+@.rules/compatibility.md

--- a/.rules/compatibility.md
+++ b/.rules/compatibility.md
@@ -1,0 +1,57 @@
+# Compatibility
+
+Nesso is in alpha (`0.1.x`). The hard rule **no backwards-compatibility code while in alpha** is in force: persisted data created by older alpha builds may break, and that is acceptable. Do not add migration shims, legacy fallbacks, or `oldName ?? newName` coercions for data at rest. Update seeds/fixtures and call sites directly and break cleanly.
+
+This file documents the **contracts** that compatibility work will eventually formalize — the migration ladders themselves are deferred to the first beta tag.
+
+## Three contracts
+
+| Contract               | What it covers                                                                                                                | Version axis                                                                         |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **Data at rest**       | Graph `.json` files, IndexedDB (`graphs` + `reviewState`), Zustand persist blob, workspace manifest (see surface table below) | `GRAPH_FORMAT_VERSION`, `vocabulary.version`, internal persist/IDB/manifest versions |
+| **Published packages** | `@nesso-how/*` on npm, MCP tool payloads                                                                                      | npm semver                                                                           |
+| **Runtime in-memory**  | React Flow state, UI, mentor chat                                                                                             | No compat — break cleanly                                                            |
+
+Only **data at rest** will get migration ladders (at beta). Package semver and MCP parity follow their own rules (see `AGENTS.md` docs/MCP section).
+
+## Data-at-rest surfaces
+
+"Data at rest" is not one thing — it is several persisted surfaces, each with its own version axis and current state. Migration is not only about graph JSON.
+
+| Surface                                                      | Versioned?             | Mechanism today                                                   | Beta migration                              |
+| ------------------------------------------------------------ | ---------------------- | ----------------------------------------------------------------- | ------------------------------------------- |
+| Graph `.json` envelope (`concepts`/`relations`)              | `GRAPH_FORMAT_VERSION` | `deserialize` throws on mismatch                                  | ladder in `deserialize` (single chokepoint) |
+| Vocabulary semantics in files (`relation.type`, node params) | `vocabulary.version`   | written, **not re-read**                                          | app-side ladder                             |
+| IDB `graphs` store (`GraphRecord`: runtime nodes/edges)      | none                   | none — already runtime shape                                      | runtime normalizer                          |
+| IDB `reviewState` store (FSRS per node)                      | none                   | none                                                              | tied to vocabulary ladder                   |
+| IDB **schema** (object stores)                               | idb `v2`               | idempotent `upgrade()` bootstrap (ensure-store-exists, no ladder) | extend `upgrade()` callback                 |
+| Zustand persist blob (localStorage `nesso`)                  | none                   | additive `merge` only                                             | `version` + `migrate`                       |
+| Workspace manifest (`.nesso` on disk)                        | `MANIFEST_VERSION`     | default-on-missing, no ladder                                     | ladder if shape changes                     |
+| Width keys (`nesso-inspector-width`, `nesso-sidebar-width`)  | none                   | none                                                              | break cleanly (trivial scalars)             |
+
+Two distinctions that matter:
+
+- **IDB schema vs IDB content.** `db.ts` declares the current _object stores_ via `idb`'s `upgrade` callback. This is **idempotent bootstrap** ("ensure these stores exist"), **not** a migration ladder: IndexedDB mandates a version number + upgrade transaction to create stores, but the callback carries no version history and migrates no data. It does **not** version the _shape_ of `GraphRecord` or `reviewState` records — a record-shape change is not covered.
+- **File ≠ what the user loaded.** On web, IndexedDB `graphs` is authoritative, not the file. A vocabulary change at beta must migrate **three** runtime entry points that bypass `deserialize`: IDB load (`graph-management` `loadGraph`), bundled seeds (`seedGraph`), and the file path (`documentToGraph`). Those three are not funnelled through one normalizer today — unifying them is the beta-time refactor (no migration logic is built in alpha).
+
+## Two version axes on graph files
+
+- **`version` (`GRAPH_FORMAT_VERSION`)** — envelope shape (`concepts`/`relations`, top-level keys), owned by `@nesso-how/schema`. `deserialize` currently throws on any version mismatch (no ladder yet). Bump only when the envelope shape changes.
+- **`vocabulary.version`** — semantic vocabulary (`@nesso-how/vocab-learning` relation ids, node params, display). Independent of npm package version. Currently round-tripped but not re-read.
+
+`@nesso-how/schema` is vocabulary-agnostic. `@nesso-how/vocab-learning` validates relation types and elaboration after envelope parse.
+
+## Content / review split
+
+Shared graph JSON carries **content only** (`text`, `elaboration`, relations, display). FSRS review fields live in IndexedDB **`reviewState`** (`${graphId}:${nodeId}`). Load merges via `documentToGraph` → `mergeReviewIntoNode`. Content and review fingerprints are independent (`graphContentFingerprint` / `reviewStateFingerprint`), so a review-only change never rewrites the shared content file.
+
+## When this relaxes (beta)
+
+At the first non-alpha tag (`0.2.0-beta.0`), the formal contract begins:
+
+- Add an envelope migration ladder in `@nesso-how/schema` keyed on `version`, plus a distinct forward guard for files from newer app versions.
+- Add a vocabulary migration ladder app-side keyed on `vocabulary.version`.
+- Freeze a replay fixture per released format/vocabulary version; every future bump adds a fixture + migration step.
+- Deprecation aliases become allowed for **package consumers** (one minor cycle), never for app data at rest.
+
+Until beta, this file is the **stance**, not an implemented ladder. Beta implementation is tracked in [#82](https://github.com/nesso-how/nesso/issues/82).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ Area-specific rules (canonical content in `.rules/`, auto-attached per file area
 | `CHANGELOG.md` (Keep a Changelog), `[Unreleased]`, release flow | [`.rules/changelog.md`](.rules/changelog.md)         |
 | Keeping the `.rules/` files in sync with the codebase           | [`.rules/maintenance.md`](.rules/maintenance.md)     |
 | PR titles/bodies — match `.github/PULL_REQUEST_TEMPLATE.md`     | [`.rules/pull-requests.md`](.rules/pull-requests.md) |
+| Persisted-data compatibility — envelope/vocabulary migration    | [`.rules/compatibility.md`](.rules/compatibility.md) |
 
 **Changelog:** do **not** edit `CHANGELOG.md` during feature work; update **`## [Unreleased]`** only when the user asks for a **commit** or an explicit **changelog-before-commit** pass. Format and releases: [`.rules/changelog.md`](.rules/changelog.md).
 

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -19,11 +19,14 @@ export function reviewStateKey(graphId: string, nodeId: string): string {
 }
 
 const db = openDB<{ graphs: GraphRecord; reviewState: LearningNodeParams }>(GRAPHS_DB_NAME, 2, {
-  upgrade(db, oldVersion) {
-    if (oldVersion < 1) {
+  // Idempotent schema bootstrap: ensure the current object stores exist.
+  // Not a version ladder — IndexedDB requires a version + upgrade tx to create
+  // stores, and the version cannot go below existing alpha installs (2).
+  upgrade(db) {
+    if (!db.objectStoreNames.contains('graphs')) {
       db.createObjectStore('graphs', { keyPath: 'id' })
     }
-    if (oldVersion < 2) {
+    if (!db.objectStoreNames.contains('reviewState')) {
       db.createObjectStore('reviewState')
     }
   },


### PR DESCRIPTION
## Summary

Documents the alpha compatibility posture (break cleanly, no migration shims) and aligns IndexedDB schema setup with that stance. Migration ladders remain deferred to beta ([#82](https://github.com/nesso-how/nesso/issues/82)).

## Changes

- Add canonical `.rules/compatibility.md` with data-at-rest surface inventory and beta checklist
- Wire Cursor/Claude path-scoped wrappers and AGENTS.md rules index entry
- Replace IDB `upgrade` version ladder (`oldVersion < N`) with idempotent ensure-store-exists bootstrap

## Checklist

- [x] Branch name follows the naming convention
- [ ] `## [Unreleased]` in `CHANGELOG.md` updated — N/A (rules/docs only, no user-facing product change)

## Testing

- Pre-commit hooks (Biome, Prettier, license headers) passed on commit
- No runtime behaviour change beyond equivalent IDB store creation for fresh, v1, and v2 installs