### PR TITLE
feat(mcp): graph authoring and validation tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Added
+
+- **MCP graph tools:** `@nesso-how/mcp` exposes `validate_graph` (non-throwing document validation with errors/warnings) and `build_graph` (structured concepts/relations → importable JSON with dagre layout). Docs updated in the MCP integration guide.
+
 ## [0.1.0-alpha.37] - 2026-06-25
 
 ### Changed

--- a/docs/src/content/docs/docs/guides/mcp-integration.md
+++ b/docs/src/content/docs/docs/guides/mcp-integration.md
@@ -3,7 +3,7 @@ title: MCP
 description: Connect Nesso to Claude, Cursor, or any MCP-compatible AI client.
 ---
 
-The `@nesso-how/mcp` package is a [Model Context Protocol](https://modelcontextprotocol.io/) server that gives AI clients access to Nesso documentation and the full relation-type vocabulary. Once connected, models can answer questions about how Nesso works and use the correct relation names when you build graphs yourself in the app or in JSON.
+The `@nesso-how/mcp` package is a [Model Context Protocol](https://modelcontextprotocol.io/) server that gives AI clients access to Nesso documentation, the full relation-type vocabulary, and tools to **build** and **validate** graph documents. Once connected, models can answer questions about how Nesso works, produce importable graph JSON, and check files before writing them back to disk.
 
 ## Setup
 
@@ -40,8 +40,26 @@ Once connected, you can ask your AI client things like:
 
 - "What relation types does Nesso support?" (uses `get_relation_types`)
 - "Show me the Nesso getting started guide" (uses `get_nesso_docs`)
+- "Build a graph about photosynthesis with causes and enables relations" (uses `build_graph`)
+- "Validate this graph JSON before I save it" (uses `validate_graph`)
 
-You can build graphs in [app.nesso.how](https://app.nesso.how) yourself, or ask the model to generate a graph as a JSON file and import it via **Graph menu → Import JSON**. Use `get_relation_types` to make sure the model picks valid relation names.
+The MCP server is **stateless** and does not read or write files. Your client uses its own filesystem tools to read `.json` graph files, passes the contents inline to `validate_graph` or `build_graph`, and writes the result back. Nesso picks up external edits through its normal workspace sync.
+
+### Agent workflow for graph files
+
+A typical end-to-end flow when the client has filesystem access:
+
+1. **Read** the target graph `.json` from the project folder (client filesystem tool).
+2. **Validate** with `validate_graph` — fix any `errors` before saving; review `warnings` (e.g. missing `vocabulary` or relation `type`).
+3. **Build or extend** with `build_graph` when creating a new graph from structured concepts and relations — the tool assigns ids, vocabulary metadata, valid relation types, and layout positions.
+4. **Re-validate** the output with `validate_graph` if the client edited the JSON by hand.
+5. **Write** the JSON back to disk (client filesystem tool). Open or sync the graph in Nesso.
+
+Example prompt:
+
+> Read `graphs/biology.json` in this workspace, validate it with Nesso MCP, then use `build_graph` to add concepts "Chloroplast" and "Glucose" linked by `produces`, merge the result, re-validate, and write the file back.
+
+You can also build graphs directly in [app.nesso.how](https://app.nesso.how) or import JSON via **Graph menu → Import JSON**.
 
 ## Tools reference
 
@@ -52,3 +70,36 @@ Fetches documentation pages from this site. Call it without a `slug` to get a ta
 ### `get_relation_types`
 
 Returns the complete list of relation types grouped by category id (`taxonomic`, `structural`, … from `RELATION_CATEGORIES` in `@nesso-how/vocab-learning`), with line style, symmetry, and type properties (transitive, inverse, strength, polarity, cardinality). Use this whenever you need valid type names for graph JSON or explanations for the learner.
+
+### `validate_graph`
+
+**Input:** `{ "graph": "<json string>" }` — a Nesso graph **document** (`concepts[]`, `relations[]`), not runtime React Flow `nodes`/`edges`.
+
+**Output:** `{ "valid": boolean, "errors": [{ "path", "message" }], "warnings": [{ "path", "message" }] }`
+
+Runs envelope and vocabulary validation plus structural checks the deserializer does not cover today: duplicate ids, dangling relation endpoints, unknown relation types. Warnings flag missing `vocabulary` or relation `type` (the app falls back to `causes` at render time).
+
+`valid` is `true` only when `errors` is empty.
+
+### `build_graph`
+
+**Input:**
+
+```json
+{
+  "name": "Photosynthesis",
+  "concepts": [
+    "Sunlight",
+    {
+      "text": "Chloroplast",
+      "elaboration": { "definition": "...", "examples": "...", "notes": "" }
+    }
+  ],
+  "relations": [{ "from": "Sunlight", "to": "Chloroplast", "relation": "enables" }]
+}
+```
+
+- `concepts` — label strings or objects with optional `id`, `text`, and `elaboration`.
+- `relations` — `from` / `to` match concept `id` or label (must be unambiguous); `relation` must be a valid type id from `get_relation_types`.
+
+**Output:** Pretty-printed graph document JSON ready to write to disk (includes `vocabulary`, generated ids, and dagre layout positions). FSRS review fields and React Flow edge shape (`type: "nesso"`, handles) are applied by the app on import, not stored in the file.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -21,7 +21,7 @@ Add to your MCP client (Cursor, Claude Desktop, etc.):
 }
 ```
 
-Tools: `get_relation_types`, `get_nesso_docs`.
+Tools: `get_relation_types`, `get_nesso_docs`, `validate_graph`, `build_graph`.
 
 Full guide: [MCP integration](https://nesso.how/docs/guides/mcp-integration/).
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -25,11 +25,13 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
+    "dagre": "^0.8.5",
     "zod": "^4.4.3",
     "@modelcontextprotocol/server": "^2.0.0-alpha.2",
     "@nesso-how/vocab-learning": "workspace:*"
   },
   "devDependencies": {
+    "@types/dagre": "^0.7.53",
     "@types/node": "^22.0.0",
     "typescript": "~5.8.3"
   }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: MIT
 import { readFileSync } from 'node:fs'
 import { McpServer, StdioServerTransport } from '@modelcontextprotocol/server'
+import { registerBuildGraph } from './tools/build-graph.js'
 import { registerGetRelationTypes } from './tools/get-relation-types.js'
 import { registerGetDocs } from './tools/get-docs.js'
+import { registerValidateGraph } from './tools/validate-graph.js'
 
 const { version } = JSON.parse(
   readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
@@ -16,6 +18,8 @@ const server = new McpServer({
 
 registerGetRelationTypes(server)
 registerGetDocs(server)
+registerValidateGraph(server)
+registerBuildGraph(server)
 
 async function main() {
   const transport = new StdioServerTransport()

--- a/packages/mcp/src/lib/graph-tools.test.ts
+++ b/packages/mcp/src/lib/graph-tools.test.ts
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: MIT
+import { describe, expect, it } from 'vitest'
+import { serialize } from '@nesso-how/vocab-learning'
+import {
+  buildGraphDocument,
+  buildGraphJson,
+  newElementId,
+  validateGraphJson,
+} from './graph-tools.js'
+
+const validDoc = {
+  vocabulary: { id: '@nesso-how/vocab-learning', version: '0.1.0' },
+  name: 'Demo',
+  concepts: [
+    { id: 'n1', label: 'Cause', x: 0, y: 0 },
+    { id: 'n2', label: 'Effect', x: 250, y: 0 },
+  ],
+  relations: [{ id: 'e1', source: 'n1', target: 'n2', type: 'causes' as const }],
+}
+
+describe('validateGraphJson', () => {
+  it('accepts a valid graph document', () => {
+    const result = validateGraphJson(serialize(validDoc))
+    expect(result.valid).toBe(true)
+    expect(result.errors).toEqual([])
+  })
+
+  it('rejects invalid JSON', () => {
+    const result = validateGraphJson('{not json')
+    expect(result.valid).toBe(false)
+    expect(result.errors[0]?.message).toMatch(/Invalid JSON/)
+  })
+
+  it('rejects runtime nodes/edges shape', () => {
+    const result = validateGraphJson(
+      JSON.stringify({
+        nodes: [{ id: 'n1' }],
+        edges: [{ id: 'e1', source: 'n1', target: 'n2' }],
+      }),
+    )
+    expect(result.valid).toBe(false)
+    expect(result.errors[0]?.message).toMatch(/concepts\[\] and relations\[\]/)
+  })
+
+  it('rejects unknown relation types', () => {
+    const result = validateGraphJson(
+      JSON.stringify({
+        name: 'X',
+        concepts: [{ id: 'n1', label: 'A', x: 0, y: 0 }],
+        relations: [{ id: 'e1', source: 'n1', target: 'n1', type: 'not-real' }],
+      }),
+    )
+    expect(result.valid).toBe(false)
+    expect(result.errors[0]?.message).toMatch(/unknown relation type/)
+  })
+
+  it('rejects duplicate concept ids', () => {
+    const result = validateGraphJson(
+      JSON.stringify({
+        name: 'X',
+        concepts: [
+          { id: 'n1', label: 'A', x: 0, y: 0 },
+          { id: 'n1', label: 'B', x: 100, y: 0 },
+        ],
+        relations: [],
+      }),
+    )
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e) => e.message.includes('Duplicate concept id'))).toBe(true)
+  })
+
+  it('rejects dangling relation endpoints', () => {
+    const result = validateGraphJson(
+      JSON.stringify({
+        name: 'X',
+        concepts: [{ id: 'n1', label: 'A', x: 0, y: 0 }],
+        relations: [{ id: 'e1', source: 'n1', target: 'missing', type: 'causes' }],
+      }),
+    )
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e) => e.path.includes('target'))).toBe(true)
+  })
+
+  it('warns when relation type is omitted', () => {
+    const result = validateGraphJson(
+      JSON.stringify({
+        name: 'X',
+        concepts: [
+          { id: 'n1', label: 'A', x: 0, y: 0 },
+          { id: 'n2', label: 'B', x: 100, y: 0 },
+        ],
+        relations: [{ id: 'e1', source: 'n1', target: 'n2' }],
+      }),
+    )
+    expect(result.valid).toBe(true)
+    expect(result.warnings.some((w) => w.path.includes('type'))).toBe(true)
+  })
+
+  it('warns when vocabulary is missing', () => {
+    const result = validateGraphJson(
+      JSON.stringify({
+        name: 'X',
+        concepts: [{ id: 'n1', label: 'A', x: 0, y: 0 }],
+        relations: [],
+      }),
+    )
+    expect(result.valid).toBe(true)
+    expect(result.warnings.some((w) => w.path === 'vocabulary')).toBe(true)
+  })
+})
+
+describe('buildGraphDocument', () => {
+  it('builds a document that passes validation', () => {
+    const json = buildGraphJson({
+      name: 'Built',
+      concepts: ['Cause', 'Effect'],
+      relations: [{ from: 'Cause', to: 'Effect', relation: 'causes' }],
+    })
+    const result = validateGraphJson(json)
+    expect(result.valid).toBe(true)
+  })
+
+  it('resolves from/to by concept id', () => {
+    const doc = buildGraphDocument({
+      name: 'Refs',
+      concepts: [{ id: 'n_alpha', text: 'Alpha' }, 'Beta'],
+      relations: [{ from: 'n_alpha', to: 'Beta', relation: 'enables' }],
+    })
+    expect(doc.relations[0]?.source).toBe('n_alpha')
+    expect(doc.relations[0]?.type).toBe('enables')
+  })
+
+  it('assigns finite layout coordinates', () => {
+    const doc = buildGraphDocument({
+      name: 'Layout',
+      concepts: ['A', 'B', 'C', 'D'],
+      relations: [
+        { from: 'A', to: 'B', relation: 'causes' },
+        { from: 'B', to: 'C', relation: 'causes' },
+        { from: 'C', to: 'D', relation: 'causes' },
+      ],
+    })
+    for (const concept of doc.concepts) {
+      expect(Number.isFinite(concept.x)).toBe(true)
+      expect(Number.isFinite(concept.y)).toBe(true)
+    }
+    const xs = doc.concepts.map((c) => c.x)
+    expect(new Set(xs).size).toBeGreaterThan(1)
+  })
+
+  it('includes vocabulary metadata', () => {
+    const doc = buildGraphDocument({
+      name: 'Meta',
+      concepts: ['Only'],
+      relations: [],
+    })
+    expect(doc.vocabulary).toEqual({ id: '@nesso-how/vocab-learning', version: '0.1.0' })
+  })
+
+  it('rejects ambiguous label references', () => {
+    expect(() =>
+      buildGraphDocument({
+        name: 'Ambiguous',
+        concepts: ['Same', 'Same'],
+        relations: [{ from: 'Same', to: 'Same', relation: 'causes' }],
+      }),
+    ).toThrow(/Ambiguous concept reference/)
+  })
+
+  it('rejects unknown references', () => {
+    expect(() =>
+      buildGraphDocument({
+        name: 'Missing',
+        concepts: ['A'],
+        relations: [{ from: 'A', to: 'Z', relation: 'causes' }],
+      }),
+    ).toThrow(/Unknown concept reference/)
+  })
+})
+
+describe('newElementId', () => {
+  it('generates unique ids with the expected prefix', () => {
+    const used = new Set<string>()
+    const id = newElementId('n', used)
+    expect(id.startsWith('n')).toBe(true)
+    expect(id.length).toBe(6)
+    used.add(id)
+    const next = newElementId('n', used)
+    expect(next).not.toBe(id)
+  })
+})

--- a/packages/mcp/src/lib/graph-tools.ts
+++ b/packages/mcp/src/lib/graph-tools.ts
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: MIT
+import dagre from 'dagre'
+import * as z from 'zod/v4'
+import {
+  deserialize,
+  serialize,
+  VOCABULARY,
+  RELATION_TYPE_VALUES,
+  type ConceptElaboration,
+  type NessoGraphDocumentInput,
+  type RelationTypeName,
+} from '@nesso-how/vocab-learning'
+
+export interface GraphValidationIssue {
+  path: string
+  message: string
+}
+
+export interface GraphValidationResult {
+  valid: boolean
+  errors: GraphValidationIssue[]
+  warnings: GraphValidationIssue[]
+}
+
+const elaborationSchema = z.object({
+  definition: z.string(),
+  examples: z.string(),
+  notes: z.string(),
+  imageUrl: z.string().optional(),
+  imageTitle: z.string().optional(),
+  imageDescriptionUrl: z.string().optional(),
+})
+
+export const relationTypeEnum = z.enum(
+  RELATION_TYPE_VALUES as [RelationTypeName, ...RelationTypeName[]],
+)
+
+const conceptInputSchema = z.union([
+  z.string().describe('Concept label text'),
+  z.object({
+    id: z.string().optional().describe('Optional stable concept id (n-prefix recommended)'),
+    text: z.string().describe('Concept label'),
+    elaboration: elaborationSchema.optional(),
+  }),
+])
+
+export const buildGraphInputSchema = z.object({
+  name: z.string().describe('Graph display name'),
+  concepts: z
+    .array(conceptInputSchema)
+    .min(1)
+    .describe('Concept labels or objects with optional id and elaboration'),
+  relations: z
+    .array(
+      z.object({
+        from: z.string().describe('Source concept id or label text'),
+        to: z.string().describe('Target concept id or label text'),
+        relation: relationTypeEnum.describe('Semantic relation type id'),
+      }),
+    )
+    .describe('Directed relations between concepts'),
+})
+
+export type BuildGraphInput = z.infer<typeof buildGraphInputSchema>
+
+const NODE_WIDTH = 180
+const NODE_HEIGHT = 60
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : null
+}
+
+/** Short element id (`n`/`e` + 5 base36 chars), retried until unique within `used`. */
+export function newElementId(prefix: 'n' | 'e', used: ReadonlySet<string>): string {
+  for (;;) {
+    const id = prefix + Math.random().toString(36).slice(2, 7)
+    if (!used.has(id)) return id
+  }
+}
+
+function issue(path: string, message: string): GraphValidationIssue {
+  return { path, message }
+}
+
+function detectRuntimeFormat(root: Record<string, unknown>): GraphValidationIssue | null {
+  const hasDocumentShape = Array.isArray(root.concepts) && Array.isArray(root.relations)
+  const hasRuntimeShape = Array.isArray(root.nodes) || Array.isArray(root.edges)
+  if (hasRuntimeShape && !hasDocumentShape) {
+    return issue(
+      '$',
+      'Expected graph document format with concepts[] and relations[], not runtime nodes/edges',
+    )
+  }
+  return null
+}
+
+function collectStructuralIssues(doc: NessoGraphDocumentInput): {
+  errors: GraphValidationIssue[]
+  warnings: GraphValidationIssue[]
+} {
+  const errors: GraphValidationIssue[] = []
+  const warnings: GraphValidationIssue[] = []
+
+  if (doc.vocabulary === undefined) {
+    warnings.push(
+      issue('vocabulary', 'Missing vocabulary reference; import works but metadata is incomplete'),
+    )
+  }
+
+  const conceptIds = new Set<string>()
+  for (let i = 0; i < doc.concepts.length; i++) {
+    const id = doc.concepts[i].id
+    if (conceptIds.has(id)) {
+      errors.push(issue(`concepts[${i}].id`, `Duplicate concept id "${id}"`))
+    }
+    conceptIds.add(id)
+  }
+
+  const relationIds = new Set<string>()
+  for (let i = 0; i < doc.relations.length; i++) {
+    const rel = doc.relations[i]
+    if (relationIds.has(rel.id)) {
+      errors.push(issue(`relations[${i}].id`, `Duplicate relation id "${rel.id}"`))
+    }
+    relationIds.add(rel.id)
+
+    if (!conceptIds.has(rel.source)) {
+      errors.push(
+        issue(
+          `relations[${i}].source`,
+          `Source "${rel.source}" does not reference an existing concept id`,
+        ),
+      )
+    }
+    if (!conceptIds.has(rel.target)) {
+      errors.push(
+        issue(
+          `relations[${i}].target`,
+          `Target "${rel.target}" does not reference an existing concept id`,
+        ),
+      )
+    }
+    if (rel.type === undefined) {
+      warnings.push(
+        issue(
+          `relations[${i}].type`,
+          'Missing relation type; the app falls back to "causes" at render time',
+        ),
+      )
+    }
+  }
+
+  return { errors, warnings }
+}
+
+/** Non-throwing validation for Nesso graph document JSON strings. */
+export function validateGraphJson(graph: string): GraphValidationResult {
+  const errors: GraphValidationIssue[] = []
+  const warnings: GraphValidationIssue[] = []
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(graph)
+  } catch {
+    return {
+      valid: false,
+      errors: [issue('$', 'Invalid JSON')],
+      warnings,
+    }
+  }
+
+  const root = asRecord(parsed)
+  if (!root) {
+    return {
+      valid: false,
+      errors: [issue('$', 'Graph document root must be a JSON object')],
+      warnings,
+    }
+  }
+
+  const runtimeIssue = detectRuntimeFormat(root)
+  if (runtimeIssue) {
+    return { valid: false, errors: [runtimeIssue], warnings }
+  }
+
+  try {
+    const doc = deserialize(graph)
+    const structural = collectStructuralIssues(doc)
+    errors.push(...structural.errors)
+    warnings.push(...structural.warnings)
+  } catch (err) {
+    errors.push(issue('$', err instanceof Error ? err.message : 'Graph document failed validation'))
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+  }
+}
+
+type ResolvedConcept = {
+  id: string
+  label: string
+  elaboration?: ConceptElaboration
+}
+
+function normalizeConceptInputs(input: BuildGraphInput['concepts']): ResolvedConcept[] {
+  const usedIds = new Set<string>()
+  return input.map((item) => {
+    if (typeof item === 'string') {
+      const id = newElementId('n', usedIds)
+      usedIds.add(id)
+      return { id, label: item }
+    }
+    const id = item.id ?? newElementId('n', usedIds)
+    if (usedIds.has(id)) {
+      throw new Error(`Duplicate concept id "${id}" in build_graph input`)
+    }
+    usedIds.add(id)
+    return { id, label: item.text, elaboration: item.elaboration }
+  })
+}
+
+function resolveConceptRef(ref: string, concepts: ResolvedConcept[]): string {
+  const byId = concepts.find((c) => c.id === ref)
+  if (byId) return byId.id
+
+  const byLabel = concepts.filter((c) => c.label === ref)
+  if (byLabel.length === 1) return byLabel[0].id
+  if (byLabel.length > 1) {
+    throw new Error(`Ambiguous concept reference "${ref}" — multiple concepts share that label`)
+  }
+
+  throw new Error(`Unknown concept reference "${ref}" — use an id or unique label`)
+}
+
+function buildDagreGraph(
+  concepts: ResolvedConcept[],
+  relations: { source: string; target: string }[],
+): dagre.graphlib.Graph {
+  const g = new dagre.graphlib.Graph()
+  g.setDefaultEdgeLabel(() => ({}))
+  g.setGraph({ rankdir: 'LR', nodesep: 80, ranksep: 120 })
+  for (const concept of concepts) {
+    g.setNode(concept.id, { width: NODE_WIDTH, height: NODE_HEIGHT })
+  }
+  for (const rel of relations) {
+    if (g.hasNode(rel.source) && g.hasNode(rel.target)) {
+      g.setEdge(rel.source, rel.target)
+    }
+  }
+  dagre.layout(g)
+  return g
+}
+
+function dagreNodePosition(
+  layout: { x?: number; y?: number } | undefined,
+): { x: number; y: number } | null {
+  if (layout?.x === undefined || layout?.y === undefined) return null
+  return { x: layout.x - NODE_WIDTH / 2, y: layout.y - NODE_HEIGHT / 2 }
+}
+
+function gridFallbackPosition(index: number): { x: number; y: number } {
+  const col = index % 4
+  const row = Math.floor(index / 4)
+  return { x: col * 250, y: row * 120 }
+}
+
+function layoutConceptPositions(
+  concepts: ResolvedConcept[],
+  relations: { source: string; target: string }[],
+): Map<string, { x: number; y: number }> {
+  const positions = new Map<string, { x: number; y: number }>()
+  const g = buildDagreGraph(concepts, relations)
+
+  for (const concept of concepts) {
+    const pos = dagreNodePosition(g.node(concept.id))
+    if (pos) positions.set(concept.id, pos)
+  }
+
+  let fallbackIndex = 0
+  for (const concept of concepts) {
+    if (positions.has(concept.id)) continue
+    positions.set(concept.id, gridFallbackPosition(fallbackIndex))
+    fallbackIndex += 1
+  }
+
+  return positions
+}
+
+/** Build a valid Nesso graph document from structured agent input. */
+export function buildGraphDocument(input: BuildGraphInput): NessoGraphDocumentInput {
+  const resolvedConcepts = normalizeConceptInputs(input.concepts)
+
+  const relations = input.relations.map((rel) => ({
+    source: resolveConceptRef(rel.from, resolvedConcepts),
+    target: resolveConceptRef(rel.to, resolvedConcepts),
+    type: rel.relation,
+  }))
+
+  const usedEdgeIds = new Set<string>()
+  const documentRelations = relations.map((rel) => ({
+    id: newElementId('e', usedEdgeIds),
+    source: rel.source,
+    target: rel.target,
+    type: rel.type,
+  }))
+
+  const positions = layoutConceptPositions(resolvedConcepts, relations)
+
+  const concepts = resolvedConcepts.map((concept) => {
+    const pos = positions.get(concept.id) ?? { x: 0, y: 0 }
+    return {
+      id: concept.id,
+      label: concept.label,
+      x: pos.x,
+      y: pos.y,
+      ...(concept.elaboration !== undefined ? { data: { elaboration: concept.elaboration } } : {}),
+    }
+  })
+
+  return {
+    vocabulary: { id: VOCABULARY.id, version: VOCABULARY.version },
+    name: input.name,
+    concepts,
+    relations: documentRelations,
+  }
+}
+
+/** Serialize a built graph document to importable JSON. */
+export function buildGraphJson(input: BuildGraphInput): string {
+  return serialize(buildGraphDocument(input))
+}

--- a/packages/mcp/src/tools/build-graph.ts
+++ b/packages/mcp/src/tools/build-graph.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+import type { McpServer } from '@modelcontextprotocol/server'
+import { buildGraphInputSchema, buildGraphJson } from '../lib/graph-tools.js'
+
+export function registerBuildGraph(server: McpServer): void {
+  server.registerTool(
+    'build_graph',
+    {
+      description:
+        'Build a valid Nesso graph document JSON from structured concepts and relations. ' +
+        'Assigns ids, vocabulary metadata, relation types, and dagre layout positions. ' +
+        'Returns importable JSON for the client to write to disk.',
+      inputSchema: buildGraphInputSchema,
+    },
+    async (input) => {
+      try {
+        const json = buildGraphJson(input)
+        return {
+          content: [{ type: 'text' as const, text: json }],
+        }
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: err instanceof Error ? err.message : String(err),
+            },
+          ],
+          isError: true,
+        }
+      }
+    },
+  )
+}

--- a/packages/mcp/src/tools/validate-graph.ts
+++ b/packages/mcp/src/tools/validate-graph.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+import type { McpServer } from '@modelcontextprotocol/server'
+import * as z from 'zod/v4'
+import { validateGraphJson } from '../lib/graph-tools.js'
+
+export function registerValidateGraph(server: McpServer): void {
+  server.registerTool(
+    'validate_graph',
+    {
+      description:
+        'Validate a Nesso graph document JSON string. Returns valid, errors, and warnings. ' +
+        'Checks envelope shape, vocabulary rules, duplicate ids, dangling relation endpoints, ' +
+        'and known relation types. Use after reading a graph file or before writing one back.',
+      inputSchema: z.object({
+        graph: z.string().describe('Nesso graph document as a JSON string'),
+      }),
+    },
+    async ({ graph }) => {
+      const result = validateGraphJson(graph)
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+      }
+    },
+  )
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,10 +224,16 @@ importers:
       '@nesso-how/vocab-learning':
         specifier: workspace:*
         version: link:../vocab-learning
+      dagre:
+        specifier: ^0.8.5
+        version: 0.8.5
       zod:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@types/dagre':
+        specifier: ^0.7.53
+        version: 0.7.54
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.19
@@ -2092,6 +2098,9 @@ packages:
   '@types/d3-zoom@3.0.8':
     resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
 
+  '@types/dagre@0.7.54':
+    resolution: {integrity: sha512-QjcRY+adGbYvBFS7cwv5txhVIwX1XXIUswWl+kSQTbI6NjgZydrZkEKX/etzVd7i+bCsCb40Z/xlBY5eoFuvWQ==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -2809,6 +2818,9 @@ packages:
     resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
     engines: {node: '>=12'}
 
+  dagre@0.8.5:
+    resolution: {integrity: sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==}
+
   data-uri-to-buffer@6.0.2:
     resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
     engines: {node: '>= 14'}
@@ -3309,6 +3321,9 @@ packages:
 
   grapheme-splitter@1.0.4:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
+
+  graphlib@2.1.8:
+    resolution: {integrity: sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==}
 
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
@@ -7083,6 +7098,8 @@ snapshots:
       '@types/d3-interpolate': 3.0.4
       '@types/d3-selection': 3.0.11
 
+  '@types/dagre@0.7.54': {}
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -8022,6 +8039,11 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  dagre@0.8.5:
+    dependencies:
+      graphlib: 2.1.8
+      lodash: 4.18.1
+
   data-uri-to-buffer@6.0.2: {}
 
   data-urls@7.0.0:
@@ -8623,6 +8645,10 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   grapheme-splitter@1.0.4: {}
+
+  graphlib@2.1.8:
+    dependencies:
+      lodash: 4.18.1
 
   h3@1.15.11:
     dependencies:


### PR DESCRIPTION
## Summary

Adds `validate_graph` and `build_graph` to `@nesso-how/mcp` so agent clients can produce and check Nesso graph document JSON without filesystem I/O in the server. The client reads/writes `.json` files with its own tools; MCP handles domain logic (validation, ids, vocabulary, relation types, dagre layout).

Closes #46

## Changes

- Add `validate_graph` — non-throwing validation returning `{ valid, errors, warnings }` (envelope + vocabulary via deserialize, plus duplicate ids and dangling relation endpoints)
- Add `build_graph` — structured `name` / `concepts` / `relations` input → importable `NessoGraphDocument` JSON with generated ids, `VOCABULARY` metadata, and dagre left-to-right layout
- Shared logic in `packages/mcp/src/lib/graph-tools.ts` with 15 unit tests
- Add `dagre` dependency for auto-layout
- Update MCP integration guide and package README with agent read → validate/build → write workflow

## Checklist

- [x] Branch name follows the naming convention
- [x] `## [Unreleased]` in `CHANGELOG.md` updated

## Testing

- `pnpm exec vitest run packages/mcp/src/lib/graph-tools.test.ts` — 15 passed
- `pnpm run test:coverage` — green (coverage ratchet)
- `pnpm run analyze:dead-code` — green
- `pnpm run analyze:dupes` — green (no new clones)
- `pnpm run analyze:health` — green after splitting layout helpers
- `pnpm run build:mcp` — green (docs bundle regenerated)