### PR TITLE
feat(mentor): add opt-in toggle and refresh docs

### DIFF
--- a/.rules/mentor.md
+++ b/.rules/mentor.md
@@ -1,12 +1,14 @@
 # Mentor (Socrates)
 
-`MentorPanel.tsx` is the AI chat component. The mentor is **experimental** and has a **single transport**: an OpenAI-compatible **`POST …/chat/completions`** via `fetch`. Base URL, model, and optional API key come from `aiBaseUrl`, `aiModel`, `aiApiKey`; there is no environment-variable fallback for the key, and there is **no built-in in-browser model** (the old WebGPU/`@mlc-ai/web-llm` path was removed — too small and slow to be useful).
+`MentorPanel.tsx` is the AI chat component. The mentor is **experimental** and has a **single transport**: an OpenAI-compatible **`POST …/chat/completions`** via `fetch`. Base URL, model, and optional API key come from `aiBaseUrl`, `aiModel`, `aiApiKey`; there is no environment-variable fallback for the key.
 
-Readiness is `isAiReady(settings)` (truthy `aiBaseUrl` + `aiModel`) in `src/llm/completion.ts`. When not ready, `MentorPanel` shows a short setup hint (`t.mentor.needsSetup`) and disables the input until an endpoint is configured. The default points at a local Ollama instance (`http://localhost:11434/v1`, `gemma3:4b`).
+Readiness is `isAiReady(settings)` (truthy `aiBaseUrl` + `aiModel`) in `src/llm/completion.ts`. The mentor UI mounts only when `settings.mentorEnabled` is true (`App.tsx`); when off, **Socrates** is hidden from the status bar and `mentorPanelExpanded` is forced closed. When enabled but not ready, `MentorPanel` shows a short setup hint (`t.mentor.needsSetup`) and disables the input until an endpoint is configured. The default points at a local Ollama instance (`http://localhost:11434/v1`, `gemma3:4b`).
 
 ## Setup
 
-Configure under **Settings** (gear, **⌘,**): **Appearance**, **Learning**, **AI**. The **Learning** tab opens with a **Review** group: a _Review mode_ toggle (on by default, `reviewEnabled`) plus the FSRS _Target retention_ / _Max interval_ settings, shown only while review is on (these drive the full-screen review overlay).
+Configure under **Settings** (gear, **⌘,**): **Appearance**, **Learning**, **AI**, **Privacy**. The **Learning** tab opens with a **Review** group: a _Review mode_ toggle (on by default, `reviewEnabled`) plus the FSRS _Target retention_ / _Max interval_ settings, shown only while review is on (these drive the full-screen review overlay).
+
+The **AI** tab opens with a **Mentor** group (marked _Experimental_): a _Mentor_ toggle (`mentorEnabled`, off by default) plus base URL, model, and API key fields shown only while it is on. Turning it off hides **Socrates** from the status bar and unmounts `MentorPanel`.
 
 ## Persona
 
@@ -34,7 +36,7 @@ Assistant replies render as plain text with subtle emphasis via **`renderWithEmp
 
 ## Panel open/closed
 
-Whether the mentor **sheet** is open is `mentorPanelExpanded` on `useGraphStore`, updated via `setMentorPanelExpanded`. It is persisted with the rest of UI chrome (`zustand` `persist` → localStorage). The entry point is the **Socrates button in the `StatusBar`** (no floating FAB); the sheet slides up above the status bar and dodges the docked inspector via `leftInset`/`rightInset` props.
+Whether the mentor **sheet** is open is `mentorPanelExpanded` on `useGraphStore`, updated via `setMentorPanelExpanded`. It is persisted with the rest of UI chrome (`zustand` `persist` → localStorage). When `mentorEnabled` is true, the entry point is the **Socrates button in the `StatusBar`** (no floating FAB); the sheet slides up above the status bar and dodges the docked inspector via `leftInset`/`rightInset` props. When `mentorEnabled` is false, the button and `MentorPanel` are not rendered.
 
 ## Message history
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,14 +6,14 @@ Nesso is an app for building typed knowledge graphs for active learning: an inte
 
 ## Stack
 
-| Layer         | Technology                                                                                                                                                     |
-| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Framework     | React 18 + Vite + TypeScript                                                                                                                                   |
-| Desktop shell | Tauri v2 (`src-tauri/`) — optional wrapper; web app still runs with `pnpm dev`                                                                                 |
-| Graph canvas  | React Flow (`@xyflow/react`)                                                                                                                                   |
-| State         | Zustand (`src/store/index.ts` + `src/store/slices/`)                                                                                                           |
-| AI mentor     | **Experimental.** Any OpenAI-compatible `chat/completions` endpoint (local Ollama or cloud; endpoint / model / key in Settings). No built-in in-browser model. |
-| Review (FSRS) | Spaced-repetition scheduling via `ts-fsrs`; per-node `stability`, `difficulty`, `due`, and ratings persisted. Independent of the AI mentor.                    |
+| Layer         | Technology                                                                                                                                  |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Framework     | React 18 + Vite + TypeScript                                                                                                                |
+| Desktop shell | Tauri v2 (`src-tauri/`) — optional wrapper; web app still runs with `pnpm dev`                                                              |
+| Graph canvas  | React Flow (`@xyflow/react`)                                                                                                                |
+| State         | Zustand (`src/store/index.ts` + `src/store/slices/`)                                                                                        |
+| AI mentor     | **Experimental.** OpenAI-compatible `chat/completions` endpoint (local Ollama or cloud; Settings → AI).                                     |
+| Review (FSRS) | Spaced-repetition scheduling via `ts-fsrs`; per-node `stability`, `difficulty`, `due`, and ratings persisted. Independent of the AI mentor. |
 
 ## Source layout
 

--- a/README.md
+++ b/README.md
@@ -24,16 +24,16 @@
 
 ## What it does
 
-Nesso is an interactive concept map where nodes are ideas and edges are typed semantic relations. You draw connections between concepts, pick the relation (e.g. `causes`, `requires`, `subtype-of`), and each concept carries spaced-repetition state. **Socrates**, a Socratic AI mentor, reads the current graph and your selection, then probes your understanding through questions rather than explanations.
+Nesso is an interactive concept map where nodes are ideas and edges are typed semantic relations. You draw connections between concepts, pick the relation (e.g. `causes`, `requires`, `subtype-of`), and each concept carries spaced-repetition state. **Socrates**, a Socratic AI mentor, can read the current graph and your selection, then probe your understanding through questions rather than explanations.
 
 > [!WARNING]
-> **Early alpha.** The typed graph and spaced-repetition review work today; the Socratic mentor is experimental and needs an OpenAI-compatible endpoint (e.g. a local Ollama model or a cloud provider). There is no built-in model. Expect breaking changes.
+> **Early alpha.** The typed graph and spaced-repetition review work today; the Socratic mentor is experimental and needs an OpenAI-compatible endpoint (e.g. a local Ollama model or a cloud provider). Expect breaking changes.
 
 ## Features
 
 - **Typed knowledge graph**: 52 semantic relations across 8 categories, with inverse pairs; each type renders with a distinct line style and glyph
 - **Spaced-repetition review**: FSRS scheduling via [`ts-fsrs`](https://github.com/open-spaced-repetition/ts-fsrs); rate Again / Hard / Good / Easy
-- **Socratic AI mentor** (experimental): context-aware dialogue that probes rather than explains; connects to any OpenAI-compatible endpoint (local Ollama or a cloud provider)
+- **Socratic AI mentor**: context-aware dialogue that probes rather than explains; connects to any OpenAI-compatible endpoint (local Ollama or a cloud provider)
 - **Multi-graph workspace**: create and switch between graphs; persisted in IndexedDB (web) and mirrored to `.json` files on disk (desktop)
 - **Cross-platform**: web app at [app.nesso.how](https://app.nesso.how) plus a Tauri v2 macOS desktop build
 
@@ -81,7 +81,7 @@ Nesso is a React 18 + Vite + TypeScript single-page app, optionally wrapped by T
 
 The canvas is built on [React Flow](https://reactflow.dev/) via `@nesso-how/graph` (`NessoEdge`, `ConceptNodeBody`); the app adds an interactive `ConceptNode` wrapper for inline edit and connection handles. Each edge renders its semantic relation as a distinct line style plus an SVG glyph. Every node carries FSRS scheduling fields (`stability`, `difficulty`, `due`, `lastRating`) consumed by the Review overlay.
 
-The AI mentor in [src/llm/](src/llm/) is experimental and talks to any **OpenAI-compatible** `chat/completions` endpoint (a local Ollama model or a cloud provider). On every send the system prompt is rebuilt from the live store, so the model always sees the current graph snapshot, selection, and a focal neighbourhood.
+The AI mentor in [src/llm/](src/llm/) talks to any **OpenAI-compatible** `chat/completions` endpoint (a local Ollama model or a cloud provider). On every send the system prompt is rebuilt from the live store, so the model always sees the current graph snapshot, selection, and a focal neighbourhood.
 
 The repo is a **pnpm workspace** monorepo. The graph vocabulary lives in [packages/vocab-learning](packages/vocab-learning) and is consumed by both the app and an MCP server in [packages/mcp](packages/mcp) that exposes relation types from the vocabulary and bundled documentation to MCP-capable LLM clients.
 

--- a/docs/src/components/Landing.astro
+++ b/docs/src/components/Landing.astro
@@ -406,7 +406,7 @@ const homeHref = lang === 'en' ? '/' : `/${lang}/`
 
       .principle-visual .pv-picker,
       .principle-visual .pv-review,
-      .principle-visual .pv-aimode,
+      .principle-visual .pv-storage,
       .principle-visual .pv-module {
         box-shadow: var(--shadow-md);
       }
@@ -599,8 +599,8 @@ const homeHref = lang === 'en' ? '/' : `/${lang}/`
         transform: translate(2px, -2px);
       }
 
-      /* P3: AI mode toggle */
-      .pv-aimode {
+      /* P4: Local storage */
+      .pv-storage {
         background: var(--bg-elev);
         border: 0.5px solid var(--line);
         border-radius: 12px;
@@ -610,7 +610,7 @@ const homeHref = lang === 'en' ? '/' : `/${lang}/`
         gap: 0.65rem;
       }
 
-      .pv-aimode-header {
+      .pv-storage-header {
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -622,81 +622,62 @@ const homeHref = lang === 'en' ? '/' : `/${lang}/`
         white-space: nowrap;
       }
 
-      .pv-aimode-header > span {
-        white-space: nowrap;
+      .pv-storage-header > span:last-child {
+        color: var(--highlight);
       }
 
-      .pv-aimode-options {
+      .pv-storage-folder {
         display: flex;
-        flex-direction: column;
-        gap: 0.4rem;
-      }
-
-      .pv-aimode-option {
-        display: flex;
-        align-items: flex-start;
-        gap: 0.55rem;
-        padding: 0.5rem 0.55rem;
+        align-items: center;
+        gap: 0.45rem;
+        padding: 0.45rem 0.55rem;
         border: 0.5px solid var(--line);
         border-radius: 7px;
         background: var(--paper);
       }
 
-      .pv-aimode-option.active {
-        background: var(--highlight-soft);
-        border-color: color-mix(in srgb, var(--highlight) 35%, transparent);
-      }
-
-      .pv-aimode-option.muted {
-        opacity: 0.65;
-      }
-
-      .pv-aimode-radio {
-        width: 12px;
-        height: 12px;
-        border: 1px solid var(--ink-4);
-        border-radius: 50%;
+      .pv-storage-folder-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
         flex-shrink: 0;
-        margin-top: 1px;
-        position: relative;
+        color: var(--ink-3);
       }
 
-      .pv-aimode-option.active .pv-aimode-radio {
-        border-color: var(--highlight);
+      .pv-storage-path {
+        font-family: var(--font-mono);
+        font-size: 10.5px;
+        color: var(--ink-2);
+        letter-spacing: 0.01em;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
 
-      .pv-aimode-option.active .pv-aimode-radio::after {
-        content: '';
-        position: absolute;
-        inset: 2px;
-        background: var(--highlight);
-        border-radius: 50%;
-      }
-
-      .pv-aimode-text {
-        flex: 1;
+      .pv-storage-files {
         display: flex;
         flex-direction: column;
-        gap: 1px;
-        min-width: 0;
+        gap: 0.3rem;
+        padding-left: 0.15rem;
       }
 
-      .pv-aimode-name {
-        font-family: var(--font-sans);
-        font-weight: 500;
-        font-size: 12px;
-        color: var(--ink);
-      }
-
-      .pv-aimode-meta {
+      .pv-storage-file {
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
         font-family: var(--font-mono);
-        font-size: 9.5px;
-        color: var(--ink-4);
-        letter-spacing: 0.02em;
+        font-size: 10px;
+        color: var(--ink-3);
+        letter-spacing: 0.01em;
       }
 
-      .pv-aimode-option.active .pv-aimode-meta {
-        color: var(--highlight);
+      .pv-storage-file::before {
+        content: '';
+        width: 4px;
+        height: 4px;
+        border-radius: 50%;
+        background: var(--ink-4);
+        flex-shrink: 0;
       }
 
       /* P1: Relation picker */
@@ -1399,26 +1380,30 @@ const homeHref = lang === 'en' ? '/' : `/${lang}/`
               <p set:html={t.principles.p4.body} />
             </div>
             <div class="principle-visual">
-              <div class="pv-aimode" role="presentation">
-                <div class="pv-aimode-header">
-                  <span>{t.principles.p4.aiMode}</span>
-                  <span>{t.principles.p4.settings}</span>
+              <div class="pv-storage" role="presentation">
+                <div class="pv-storage-header">
+                  <span>{t.principles.p4.storage}</span>
+                  <span>{t.principles.p4.noAccount}</span>
                 </div>
-                <div class="pv-aimode-options">
-                  <div class="pv-aimode-option active">
-                    <span class="pv-aimode-radio"></span>
-                    <div class="pv-aimode-text">
-                      <span class="pv-aimode-name">{t.principles.p4.local}</span>
-                      <span class="pv-aimode-meta">{t.principles.p4.localMeta}</span>
-                    </div>
-                  </div>
-                  <div class="pv-aimode-option muted">
-                    <span class="pv-aimode-radio"></span>
-                    <div class="pv-aimode-text">
-                      <span class="pv-aimode-name">{t.principles.p4.remote}</span>
-                      <span class="pv-aimode-meta">{t.principles.p4.remoteMeta}</span>
-                    </div>
-                  </div>
+                <div class="pv-storage-folder">
+                  <span class="pv-storage-folder-icon" aria-hidden="true">
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 16 16"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="1.3"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    >
+                      <path d="M1.5 4.5h4.2l1.3 1.5H14.5v7.5H1.5z"></path>
+                    </svg>
+                  </span>
+                  <span class="pv-storage-path">~/Documents/{t.principles.p4.folder}/</span>
+                </div>
+                <div class="pv-storage-files">
+                  {t.principles.p4.files.map((file) => <span class="pv-storage-file">{file}</span>)}
                 </div>
               </div>
             </div>

--- a/docs/src/content/docs/docs/guides/ai-mentor.md
+++ b/docs/src/content/docs/docs/guides/ai-mentor.md
@@ -3,11 +3,9 @@ title: AI mentor (Socrates)
 description: How the Socratic mentor works, connecting a model, persona, and graph-aware context.
 ---
 
-:::caution
-This is the part of Nesso with the most potential and the most room to grow. Small models tend to drift out of the Socratic role and start explaining rather than questioning. A larger remote model works noticeably better. Improving the mentor is where most of the future work is headed.
-:::
+The Socratic mentor is **experimental** and **off by default**. Enable it under **Settings → AI** with the **Mentor** toggle (marked _Experimental_). While off, **Socrates** is hidden from the status bar.
 
-Click the **Socrates** entry in the **status bar** (bottom-left) to start a dialogue. The mentor reads your current graph and selection, and replies with **questions rather than explanations**. The goal is to surface what you understand and where the gaps are.
+When enabled, click **Socrates** in the **status bar** (bottom-left) to start a dialogue. The mentor reads your current graph and selection, and replies with **questions rather than explanations**. The goal is to surface what you understand and where the gaps are.
 
 ## How it works
 
@@ -17,11 +15,11 @@ Chat history is **not persisted**. It lives only for the current panel session.
 
 ## Connecting a model
 
-The mentor is **experimental** and runs against any OpenAI-compatible `chat/completions` endpoint. Configure it under **Settings -> AI**: base URL, model, and an optional API key.
+Configure any OpenAI-compatible `chat/completions` endpoint under **Settings → AI**: base URL, model, and an optional API key. Endpoint fields appear only while the mentor toggle is on.
 
 The default targets a local [Ollama](https://ollama.com/) instance (`http://localhost:11434/v1`, model `gemma3:4b`). Install Ollama, pull a model, and the mentor works with nothing leaving your machine. Any hosted OpenAI-compatible endpoint works too; set the API key it expects.
 
-There is **no built-in in-browser model**. Nesso previously bundled a small WebGPU model, but it was too small and slow to be useful and has been removed. Until a reachable endpoint is configured, the chat input stays disabled and the mentor shows a short setup hint.
+Until a reachable endpoint is configured, the chat input stays disabled and the mentor shows a short setup hint.
 
 ### Reaching local Ollama from the hosted app
 

--- a/docs/src/content/docs/docs/guides/concepts-and-inspector.md
+++ b/docs/src/content/docs/docs/guides/concepts-and-inspector.md
@@ -78,7 +78,7 @@ The Inspector shows the relation as a chip with its category colour and a dropdo
 
 ## Status bar and search
 
-- The **status bar** along the bottom shows the concept and relation counts. Its right side carries undo / redo, zoom out / in, and center·fit; the **Socrates** entry sits on the left.
+- The **status bar** along the bottom shows the concept and relation counts. Its right side carries undo / redo, zoom out / in, and center·fit. When the mentor is enabled in **Settings → AI**, the **Socrates** entry appears on the left (see [AI mentor](./ai-mentor/)).
 - **`⌘K` / `Ctrl+K`** opens a fuzzy search palette over concept titles. `Enter` selects and recenters the viewport; `Esc` closes.
 
 ## Edge encoding density

--- a/docs/src/content/docs/docs/guides/getting-started.md
+++ b/docs/src/content/docs/docs/guides/getting-started.md
@@ -3,11 +3,11 @@ title: Getting started
 description: How to run Nesso locally or on the web.
 ---
 
-Nesso is available as a hosted web app, a macOS desktop app, and as open-source code you can run locally. All data is stored in your browser or on your machine; nothing is sent to external servers unless you configure a remote AI endpoint.
+Nesso is available as a hosted web app, a macOS desktop app, and as open-source code you can run locally. Graphs are stored in your browser or on your machine (local-first, no account). Optional telemetry and desktop update checks may contact external services; using the AI mentor with a remote endpoint sends prompts to that provider.
 
 ## Web app
 
-Open [app.nesso.how](https://app.nesso.how) in your browser. The app works offline after the first load and runs in any modern browser. The AI mentor is optional and needs an OpenAI-compatible endpoint (see [Picking an AI backend](#picking-an-ai-backend)).
+Open [app.nesso.how](https://app.nesso.how) in your browser. The app works offline after the first load and runs in any modern browser.
 
 ## First run
 
@@ -56,13 +56,7 @@ pnpm build:desktop
 
 ## Picking an AI backend
 
-The Socratic mentor is **experimental** and uses any OpenAI-compatible `chat/completions` endpoint: a local [Ollama](https://ollama.com/) instance, an OpenAI-compatible proxy, or a hosted provider. There is no built-in in-browser model, so configure an endpoint under **Settings -> AI** (`⌘,` / `Ctrl+,`) or the mentor stays disabled.
-
-:::caution
-API keys are stored client-side in `localStorage`. Do not self-host the web app publicly with secrets baked in.
-:::
-
-### Local setup with Ollama
+See [AI mentor (Socrates)](./ai-mentor/) for setup, persona, context, and privacy. Quick path with local Ollama:
 
 Run [Ollama](https://ollama.com/) locally, then pull a small instruction-tuned model:
 
@@ -70,7 +64,7 @@ Run [Ollama](https://ollama.com/) locally, then pull a small instruction-tuned m
 ollama pull gemma3:4b
 ```
 
-In **Settings -> AI**, set:
+In **Settings → AI**, turn on **Mentor**, then set:
 
 - Base URL: `http://localhost:11434/v1`
 - Model: `gemma3:4b` (or `llama3.2:3b`, `qwen3:8b`; presets are shown in Settings)
@@ -79,6 +73,10 @@ In **Settings -> AI**, set:
 Settings auto-probes the endpoint and offers a **Pull** button if the model is missing. Prompts and responses stay on your machine.
 
 When using the hosted web app over HTTPS, allow its origin in Ollama so the browser request is not blocked by CORS: start Ollama with `OLLAMA_ORIGINS=https://app.nesso.how`. (Requests to `localhost` are exempt from mixed-content blocking, so only CORS needs configuring.)
+
+:::caution
+API keys are stored client-side in `localStorage`. Do not self-host the web app publicly with secrets baked in.
+:::
 
 ## Keyboard shortcuts
 

--- a/docs/src/content/docs/docs/introduction.md
+++ b/docs/src/content/docs/docs/introduction.md
@@ -23,17 +23,17 @@ Nesso inverts the flow. The learner constructs their own knowledge structure: a 
 
 Algorithms work on what the learner has built, not on a generic curriculum. Spaced repetition is driven by graph structure: concepts with low stability or untested connections surface before well-reinforced ones. The review queue is always a function of the learner's own map.
 
-AI is present, but with a constrained role. The AI mentor, Socrates, does not deliver pre-packaged answers. It asks questions calibrated to the learner's current graph, probing understanding, surfacing gaps, and leaving the work of constructing answers to the learner. It is designed to accelerate active thinking, not to replace it.
+An optional AI mentor, Socrates, can probe what you have built. It asks questions calibrated to your current graph rather than delivering answers. See [AI mentor (Socrates)](./guides/ai-mentor/) for setup and behaviour.
 
 ## Principles
 
 **Constructivist by design.** Every feature is oriented around the learner doing cognitive work: drawing edges, labelling relations, writing definitions in their own words, self-rating recall. The system does not do this work for them.
 
-**Private by architecture.** In the web app, graphs are stored locally in your browser. In the desktop app, they are also saved as plain JSON files on your machine. Your graph content, definitions, and Socrates conversations never leave your device unless you connect a remote AI endpoint yourself. Optional telemetry (anonymous crash reports and aggregated usage events) is off by default and opt-in from Settings, Privacy; it never includes graph content, chat, or keys. Privacy is an implementation detail, not a policy promise.
+**Private by architecture.** In the web app, graphs are stored locally in your browser. In the desktop app, they are also saved as plain JSON files on your machine. Your graph content and definitions stay on your device. Mentor chat is session-only in the app; if you enable the mentor and use a remote AI endpoint, prompts are sent to that provider each turn. Optional telemetry (anonymous crash reports and aggregated usage events) is off by default and opt-in from **Settings → Privacy**; it never includes graph content, chat, or keys. Privacy is an implementation detail, not a policy promise.
 
 **Open by default.** The code is MIT-licensed. Data formats are documented and importable/exportable as plain JSON. The MCP server makes the graph vocabulary available to any compatible client. Technical work done here is intended to be useful beyond this application.
 
-**Provider-agnostic AI.** Nesso talks to any OpenAI-compatible `chat/completions` endpoint. Users choose whether to run a model locally or connect a remote provider; no vendor is privileged by the architecture.
+**Provider-agnostic AI.** The mentor talks to any OpenAI-compatible `chat/completions` endpoint. You choose whether to run a model locally or connect a remote provider; no vendor is privileged by the architecture.
 
 ## What Nesso is not
 

--- a/docs/src/i18n/en.ts
+++ b/docs/src/i18n/en.ts
@@ -75,20 +75,18 @@ export const en: Locale = {
     },
     p4: {
       heading: 'Private by architecture',
-      body: 'Your cognitive graph reveals how you reason, where you struggle, how your understanding evolves. Nesso keeps it on your device with local-first storage, no account, and no servers in the loop. When you bring in AI, the endpoint is your choice: keep it fully on-device, or point it at a provider you trust. Your data stays where you put it.',
-      aiMode: 'AI endpoint',
-      settings: 'Settings',
-      local: 'Local',
-      localMeta: 'Ollama · on-device',
-      remote: 'Cloud',
-      remoteMeta: 'OpenAI · Claude · OpenRouter…',
+      body: 'Your cognitive graph reveals how you reason, where you struggle, how your understanding evolves. Nesso keeps it on your device with local-first storage and no account. Your data stays where you put it.',
+      storage: 'Local storage',
+      noAccount: 'No account',
+      folder: 'My graphs',
+      files: ['tutorial.json', 'epistemology.json', 'notes.json'],
     },
   },
   mentor: {
     label: 'Socratic mentor',
     badge: 'Experimental',
     heading: 'Then Socrates questions it',
-    body: 'Layered on top of the graph, a Socratic AI reads your current selection and answers with questions, not summaries. It is experimental and connects to any OpenAI-compatible endpoint: a local model via Ollama, or a cloud provider. Point it at a capable model for a real conversation.',
+    body: 'Layered on top of the graph, a Socratic AI reads your current selection and answers with questions, not summaries. Connect any OpenAI-compatible endpoint: a local model via Ollama, or a cloud provider. Point it at a capable model for a real conversation.',
     chat: {
       userMsg: 'Let’s explore Understanding',
       mentorMsg:

--- a/docs/src/i18n/types.ts
+++ b/docs/src/i18n/types.ts
@@ -72,12 +72,10 @@ export type Locale = {
     p4: {
       heading: string
       body: string
-      aiMode: string
-      settings: string
-      local: string
-      localMeta: string
-      remote: string
-      remoteMeta: string
+      storage: string
+      noAccount: string
+      folder: string
+      files: [string, string, string]
     }
   }
   mentor: {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,8 @@ function AppInner() {
   const onboarding = useOnboardingFlow()
 
   const settings = useGraphStore((s) => s.settings)
+  const mentorEnabled = settings.mentorEnabled
+  const setMentorPanelExpanded = useGraphStore((s) => s.setMentorPanelExpanded)
   const telemetry = settings.telemetry
   const addNode = useGraphStore((s) => s.addNode)
   const selected = useGraphStore((s) => s.selected)
@@ -92,6 +94,10 @@ function AppInner() {
     if (telemetry) void initTelemetry(true)
     else void shutdownTelemetry()
   }, [telemetry])
+
+  useEffect(() => {
+    if (!mentorEnabled) setMentorPanelExpanded(false)
+  }, [mentorEnabled, setMentorPanelExpanded])
 
   const appStartedRef = useRef(false)
   useEffect(() => {
@@ -503,12 +509,14 @@ function AppInner() {
         onPanelWidthChange={(w) => setInspectorPanelWidth(clampInspectorPanelWidth(w))}
       />
       <StatusBar sidebarWidth={sidebarWidth} onFit={fitView} />
-      <MentorPanel
-        leftInset={sidebarWidth}
-        rightInset={
-          hasSelection ? (inspectorCollapsed ? INSPECTOR_RAIL_WIDTH : inspectorPanelWidth) : 0
-        }
-      />
+      {mentorEnabled && (
+        <MentorPanel
+          leftInset={sidebarWidth}
+          rightInset={
+            hasSelection ? (inspectorCollapsed ? INSPECTOR_RAIL_WIDTH : inspectorPanelWidth) : 0
+          }
+        />
+      )}
       <ReviewMode open={showReview} onClose={() => setShowReview(false)} />
       <ShortcutsDialog open={showShortcuts} onClose={() => setShowShortcuts(false)} />
       <SettingsDialog open={showSettings} onClose={() => setShowSettings(false)} />

--- a/src/components/dialogs/SettingsDialog.tsx
+++ b/src/components/dialogs/SettingsDialog.tsx
@@ -8,6 +8,7 @@ import { ModalOverlay } from '@/components/ui/ModalOverlay'
 import { SegmentedControl } from '@/components/ui/SegmentedControl'
 import { Switch } from '@/components/ui/Switch'
 import { Select } from '@/components/ui/Select'
+import { ExperimentalBadge } from '@/components/ui/ExperimentalBadge'
 import { useT } from '@/i18n'
 import { LearningSettings } from './LearningSettings'
 import { SettingsHeatmapDefault } from '@/components/ui/HeatmapDisplayToggle'
@@ -80,7 +81,7 @@ export function SettingsDialog({ open, onClose }: Props) {
   }, [open])
 
   useEffect(() => {
-    if (!open) {
+    if (!open || !settings.mentorEnabled) {
       setModelStatus('idle')
       return
     }
@@ -96,7 +97,7 @@ export function SettingsDialog({ open, onClose }: Props) {
     return () => {
       cancelled = true
     }
-  }, [open, settings.aiBaseUrl])
+  }, [open, settings.aiBaseUrl, settings.mentorEnabled])
 
   const inputStyle: React.CSSProperties = {
     width: '100%',
@@ -298,170 +299,218 @@ export function SettingsDialog({ open, onClose }: Props) {
             )}
 
             {tab === 'ai' && (
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
-                <label style={{ display: 'block' }}>
-                  <span
-                    style={{
-                      fontSize: '13px',
-                      fontWeight: 400,
-                      fontFamily: 'var(--font-sans)',
-                      color: 'var(--ink-2)',
-                      display: 'block',
-                    }}
-                  >
-                    {t.settings.ai.apiBaseUrl}
-                  </span>
-                  <small
-                    style={{
-                      display: 'block',
-                      fontSize: '11px',
-                      fontWeight: 400,
-                      lineHeight: 1.4,
-                      fontFamily: 'var(--font-sans)',
-                      color: 'var(--ink-4)',
-                      marginTop: 3,
-                      marginBottom: 8,
-                    }}
-                  >
-                    {t.settings.ai.apiBaseUrlDesc}
-                  </small>
-                  <input
-                    type="text"
-                    value={settings.aiBaseUrl}
-                    placeholder="http://localhost:11434/v1"
-                    onChange={(e) => setSetting('aiBaseUrl', e.target.value)}
-                    style={inputStyle}
-                  />
-                </label>
-
-                <div>
-                  <span
-                    style={{
-                      fontSize: '13px',
-                      fontWeight: 400,
-                      fontFamily: 'var(--font-sans)',
-                      color: 'var(--ink-2)',
-                      display: 'block',
-                    }}
-                  >
-                    {t.settings.ai.model}
-                  </span>
-                  <small
-                    style={{
-                      display: 'block',
-                      fontSize: '11px',
-                      fontWeight: 400,
-                      lineHeight: 1.4,
-                      fontFamily: 'var(--font-sans)',
-                      color: 'var(--ink-4)',
-                      marginTop: 3,
-                      marginBottom: 10,
-                    }}
-                  >
-                    {t.settings.ai.modelDesc}
-                  </small>
-                  <div
-                    style={{
-                      display: 'flex',
-                      flexWrap: 'wrap',
-                      gap: 'var(--space-3)',
-                      marginBottom: 10,
-                    }}
-                  >
-                    {OLLAMA_PRESETS.map((p) => {
-                      const active = settings.aiModel === p.id
-                      return (
-                        <button
-                          key={p.id}
-                          type="button"
-                          title={p.note}
-                          onClick={() => {
-                            setSetting('aiModel', p.id)
-                            triggerCheck(settings.aiBaseUrl, p.id)
-                          }}
-                          style={{
-                            appearance: 'none',
-                            border: `0.5px solid ${active ? 'var(--ink-2)' : 'var(--line)'}`,
-                            background: active ? 'var(--paper-deep)' : 'transparent',
-                            color: active ? 'var(--ink)' : 'var(--ink-3)',
-                            fontSize: '11px',
-                            fontWeight: 500,
-                            fontFamily: 'var(--font-mono)',
-                            padding: '5px 10px',
-                            borderRadius: 'var(--radius-sm)',
-                            cursor: 'pointer',
-                          }}
-                        >
-                          {p.id}
-                        </button>
-                      )
-                    })}
-                  </div>
-                  <input
-                    type="text"
-                    value={settings.aiModel}
-                    placeholder="e.g. gemma3:4b"
-                    onChange={(e) => {
-                      setSetting('aiModel', e.target.value)
-                      setModelStatus('idle')
-                    }}
-                    onBlur={(e) => triggerCheck(settings.aiBaseUrl, e.target.value)}
-                    style={inputStyle}
-                  />
-                  <ModelStatusBadge
-                    status={modelStatus}
-                    model={settings.aiModel}
-                    baseUrl={settings.aiBaseUrl}
-                    pullProgress={pullProgress}
-                    onPull={() => void handlePull()}
-                  />
-                </div>
-
-                <label style={{ display: 'block' }}>
-                  <span
-                    style={{
-                      fontSize: '13px',
-                      fontWeight: 400,
-                      fontFamily: 'var(--font-sans)',
-                      color: 'var(--ink-2)',
-                      display: 'block',
-                    }}
-                  >
-                    {t.settings.ai.apiKey}
-                  </span>
-                  <small
-                    style={{
-                      display: 'block',
-                      fontSize: '11px',
-                      fontWeight: 400,
-                      lineHeight: 1.4,
-                      fontFamily: 'var(--font-sans)',
-                      color: 'var(--ink-4)',
-                      marginTop: 3,
-                      marginBottom: 8,
-                    }}
-                  >
-                    {t.settings.ai.apiKeyDesc}{' '}
-                    <code
+              <>
+                <div style={{ marginBottom: 14 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                    <span
                       style={{
-                        fontFamily: "'JetBrains Mono', ui-monospace",
-                        fontSize: 'var(--text-xs)',
+                        fontSize: '11px',
+                        fontWeight: 500,
+                        fontFamily: 'var(--font-mono)',
+                        color: 'var(--ink-4)',
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.08em',
                       }}
                     >
-                      Authorization: Bearer
-                    </code>
-                    .
+                      {t.settings.ai.mentor}
+                    </span>
+                    <ExperimentalBadge />
+                  </div>
+                  <small
+                    style={{
+                      display: 'block',
+                      fontSize: '11px',
+                      fontWeight: 400,
+                      lineHeight: 1.4,
+                      fontFamily: 'var(--font-sans)',
+                      color: 'var(--ink-4)',
+                      marginTop: 6,
+                    }}
+                  >
+                    {t.settings.ai.mentorDesc}
                   </small>
-                  <input
-                    type="password"
-                    autoComplete="off"
-                    value={settings.aiApiKey}
-                    placeholder="••••••••"
-                    onChange={(e) => setSetting('aiApiKey', e.target.value)}
-                    style={inputStyle}
-                  />
-                </label>
-              </div>
+                </div>
+
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+                  <SettingsFormRow
+                    divider={false}
+                    label={t.settings.ai.mentorMode}
+                    description={t.settings.ai.mentorModeDesc}
+                  >
+                    <Switch
+                      value={settings.mentorEnabled}
+                      onChange={(v) => setSetting('mentorEnabled', v)}
+                    />
+                  </SettingsFormRow>
+
+                  {settings.mentorEnabled && (
+                    <>
+                      <label style={{ display: 'block' }}>
+                        <span
+                          style={{
+                            fontSize: '13px',
+                            fontWeight: 400,
+                            fontFamily: 'var(--font-sans)',
+                            color: 'var(--ink-2)',
+                            display: 'block',
+                          }}
+                        >
+                          {t.settings.ai.apiBaseUrl}
+                        </span>
+                        <small
+                          style={{
+                            display: 'block',
+                            fontSize: '11px',
+                            fontWeight: 400,
+                            lineHeight: 1.4,
+                            fontFamily: 'var(--font-sans)',
+                            color: 'var(--ink-4)',
+                            marginTop: 3,
+                            marginBottom: 8,
+                          }}
+                        >
+                          {t.settings.ai.apiBaseUrlDesc}
+                        </small>
+                        <input
+                          type="text"
+                          value={settings.aiBaseUrl}
+                          placeholder="http://localhost:11434/v1"
+                          onChange={(e) => setSetting('aiBaseUrl', e.target.value)}
+                          style={inputStyle}
+                        />
+                      </label>
+
+                      <div>
+                        <span
+                          style={{
+                            fontSize: '13px',
+                            fontWeight: 400,
+                            fontFamily: 'var(--font-sans)',
+                            color: 'var(--ink-2)',
+                            display: 'block',
+                          }}
+                        >
+                          {t.settings.ai.model}
+                        </span>
+                        <small
+                          style={{
+                            display: 'block',
+                            fontSize: '11px',
+                            fontWeight: 400,
+                            lineHeight: 1.4,
+                            fontFamily: 'var(--font-sans)',
+                            color: 'var(--ink-4)',
+                            marginTop: 3,
+                            marginBottom: 10,
+                          }}
+                        >
+                          {t.settings.ai.modelDesc}
+                        </small>
+                        <div
+                          style={{
+                            display: 'flex',
+                            flexWrap: 'wrap',
+                            gap: 'var(--space-3)',
+                            marginBottom: 10,
+                          }}
+                        >
+                          {OLLAMA_PRESETS.map((p) => {
+                            const active = settings.aiModel === p.id
+                            return (
+                              <button
+                                key={p.id}
+                                type="button"
+                                title={p.note}
+                                onClick={() => {
+                                  setSetting('aiModel', p.id)
+                                  triggerCheck(settings.aiBaseUrl, p.id)
+                                }}
+                                style={{
+                                  appearance: 'none',
+                                  border: `0.5px solid ${active ? 'var(--ink-2)' : 'var(--line)'}`,
+                                  background: active ? 'var(--paper-deep)' : 'transparent',
+                                  color: active ? 'var(--ink)' : 'var(--ink-3)',
+                                  fontSize: '11px',
+                                  fontWeight: 500,
+                                  fontFamily: 'var(--font-mono)',
+                                  padding: '5px 10px',
+                                  borderRadius: 'var(--radius-sm)',
+                                  cursor: 'pointer',
+                                }}
+                              >
+                                {p.id}
+                              </button>
+                            )
+                          })}
+                        </div>
+                        <input
+                          type="text"
+                          value={settings.aiModel}
+                          placeholder="e.g. gemma3:4b"
+                          onChange={(e) => {
+                            setSetting('aiModel', e.target.value)
+                            setModelStatus('idle')
+                          }}
+                          onBlur={(e) => triggerCheck(settings.aiBaseUrl, e.target.value)}
+                          style={inputStyle}
+                        />
+                        <ModelStatusBadge
+                          status={modelStatus}
+                          model={settings.aiModel}
+                          baseUrl={settings.aiBaseUrl}
+                          pullProgress={pullProgress}
+                          onPull={() => void handlePull()}
+                        />
+                      </div>
+
+                      <label style={{ display: 'block' }}>
+                        <span
+                          style={{
+                            fontSize: '13px',
+                            fontWeight: 400,
+                            fontFamily: 'var(--font-sans)',
+                            color: 'var(--ink-2)',
+                            display: 'block',
+                          }}
+                        >
+                          {t.settings.ai.apiKey}
+                        </span>
+                        <small
+                          style={{
+                            display: 'block',
+                            fontSize: '11px',
+                            fontWeight: 400,
+                            lineHeight: 1.4,
+                            fontFamily: 'var(--font-sans)',
+                            color: 'var(--ink-4)',
+                            marginTop: 3,
+                            marginBottom: 8,
+                          }}
+                        >
+                          {t.settings.ai.apiKeyDesc}{' '}
+                          <code
+                            style={{
+                              fontFamily: "'JetBrains Mono', ui-monospace",
+                              fontSize: 'var(--text-xs)',
+                            }}
+                          >
+                            Authorization: Bearer
+                          </code>
+                          .
+                        </small>
+                        <input
+                          type="password"
+                          autoComplete="off"
+                          value={settings.aiApiKey}
+                          placeholder="••••••••"
+                          onChange={(e) => setSetting('aiApiKey', e.target.value)}
+                          style={inputStyle}
+                        />
+                      </label>
+                    </>
+                  )}
+                </div>
+              </>
             )}
 
             {tab === 'learning' && <LearningSettings />}

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -186,6 +186,7 @@ const sep: React.CSSProperties = {
 
 export function StatusBar({ sidebarWidth, onFit }: Props) {
   const t = useT()
+  const mentorEnabled = useGraphStore((s) => s.settings.mentorEnabled)
   const nodeCount = useGraphStore((s) => s.nodes.length)
   const edgeCount = useGraphStore((s) => s.edges.length)
   const undo = useGraphStore((s) => s.undo)
@@ -217,8 +218,12 @@ export function StatusBar({ sidebarWidth, onFit }: Props) {
     >
       {/* Left — Socrates anchor + graph counts */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 9, minWidth: 0 }}>
-        <SocratesEntry />
-        <span style={sep} />
+        {mentorEnabled && (
+          <>
+            <SocratesEntry />
+            <span style={sep} />
+          </>
+        )}
         <span
           style={{
             fontSize: '10.5px',

--- a/src/components/mentor/MentorPanel.tsx
+++ b/src/components/mentor/MentorPanel.tsx
@@ -395,7 +395,7 @@ export function MentorPanel({ leftInset, rightInset }: { leftInset: number; righ
           }}
         >
           <SocratesGlyph size={32} />
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 1, flex: 1 }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 1, flex: 1, minWidth: 0 }}>
             <b
               style={{
                 fontSize: '13px',

--- a/src/components/onboarding/onboardingSteps.test.ts
+++ b/src/components/onboarding/onboardingSteps.test.ts
@@ -16,6 +16,7 @@ function baseState(overrides: Partial<GraphState> = {}): GraphState {
       aiBaseUrl: '',
       aiModel: '',
       aiApiKey: '',
+      mentorEnabled: false,
       reviewEnabled: true,
       fsrsRetention: 0.9,
       maximumInterval: 365,

--- a/src/components/ui/ExperimentalBadge.tsx
+++ b/src/components/ui/ExperimentalBadge.tsx
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+import { useT } from '@/i18n'
+
+export function ExperimentalBadge() {
+  const t = useT()
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        flexShrink: 0,
+        fontFamily: 'var(--font-mono)',
+        fontSize: '10px',
+        fontWeight: 500,
+        letterSpacing: '0.12em',
+        textTransform: 'uppercase',
+        color: 'var(--ink-4)',
+        padding: '2px 7px',
+        borderRadius: 'var(--radius-pill)',
+        border: '0.5px solid var(--line-strong)',
+        lineHeight: 1.4,
+      }}
+    >
+      {t.mentor.experimental}
+    </span>
+  )
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -48,6 +48,11 @@ const en = {
       straight: 'Straight',
     },
     ai: {
+      mentor: 'Mentor',
+      mentorDesc:
+        'Socrates reads your graph and probes your understanding through questions rather than explanations. Experimental feature.',
+      mentorMode: 'Mentor',
+      mentorModeDesc: 'When off, Socrates is hidden from the status bar.',
       apiBaseUrl: 'API base URL',
       apiBaseUrlDesc: 'OpenAI-compatible endpoint. Defaults to local Ollama.',
       model: 'Model',
@@ -387,6 +392,7 @@ const en = {
   },
   mentor: {
     name: 'Socrates',
+    experimental: 'Experimental',
     toggleTitle: 'Ask Socrates',
     placeholder: (concept: string) => `Ask Socrates about "${concept}"…`,
     placeholderGraph: 'Ask Socrates about your graph…',

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -48,6 +48,11 @@ const it: typeof en = {
       straight: 'Linea',
     },
     ai: {
+      mentor: 'Mentore',
+      mentorDesc:
+        'Socrate legge il tuo grafo e verifica la tua comprensione con domande, non spiegazioni. Funzione sperimentale.',
+      mentorMode: 'Mentore',
+      mentorModeDesc: 'Quando è disattivato, Socrate non compare nella barra di stato.',
       apiBaseUrl: 'URL base API',
       apiBaseUrlDesc: 'Endpoint OpenAI-compatibile. Default: Ollama locale.',
       model: 'Modello',
@@ -388,6 +393,7 @@ const it: typeof en = {
   },
   mentor: {
     name: 'Socrate',
+    experimental: 'Sperimentale',
     toggleTitle: 'Chiedi a Socrate',
     placeholder: (concept) => `Chiedi a Socrate di "${concept}"…`,
     placeholderGraph: 'Chiedi a Socrate del tuo grafo…',

--- a/src/store/slices/settings.ts
+++ b/src/store/slices/settings.ts
@@ -27,6 +27,7 @@ export const createSettingsSlice: StateCreator<GraphState, [], [], SettingsSlice
     aiBaseUrl: 'http://localhost:11434/v1',
     aiModel: 'gemma3:4b',
     aiApiKey: '',
+    mentorEnabled: false,
     reviewEnabled: true,
     fsrsRetention: 0.9,
     maximumInterval: 365,

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -17,6 +17,7 @@ export interface NessoSettings {
   aiBaseUrl: string
   aiModel: string
   aiApiKey: string
+  mentorEnabled: boolean
   reviewEnabled: boolean
   fsrsRetention: number
   maximumInterval: number


### PR DESCRIPTION
## Summary

The Socratic mentor is now opt-in: a **Mentor** toggle in **Settings → AI** (off by default, marked experimental) controls whether Socrates appears in the status bar and whether the chat panel is mounted. Docs, landing copy, and agent rules are aligned with this behaviour and with more honest privacy wording.

## Changes

- Add `mentorEnabled` setting (default `false`) with experimental badge and conditional endpoint fields in Settings → AI
- Hide status-bar Socrates entry and unmount `MentorPanel` when the mentor is disabled
- Update landing principle 4: local-storage visual instead of AI settings mock; trim overstated privacy claims
- Refresh Starlight guides, README, and `.rules/mentor.md`; remove legacy WebGPU/in-browser model references from user-facing docs
- Add `ExperimentalBadge` component for Settings → AI section header

## Checklist

- [x] Branch name follows the naming convention
- [ ] `## [Unreleased]` in `CHANGELOG.md` updated

## Testing

- `pnpm exec tsc --noEmit`
- `pnpm test --run src/components/onboarding/onboardingSteps.test.ts`
- `pnpm build` in `docs/`
- `pnpm build` in `packages/mcp/` (doc bundle parity)
- Manual: mentor off by default; toggle on reveals Socrates + endpoint fields; toggle off hides mentor again