### PR TITLE
fix: misc UI bugs, desktop Edit menu, and mentor AI SDK migration

### DIFF
--- a/.rules/mentor.md
+++ b/.rules/mentor.md
@@ -1,6 +1,6 @@
 # Mentor (Socrates)
 
-`MentorPanel.tsx` is the AI chat component. The mentor is **experimental** and has a **single transport**: an OpenAI-compatible **`POST …/chat/completions`** via `fetch`. Base URL, model, and optional API key come from `aiBaseUrl`, `aiModel`, `aiApiKey`; there is no environment-variable fallback for the key.
+`MentorPanel.tsx` is the AI chat component. The mentor is **experimental** and has a **single transport**: an OpenAI-compatible endpoint driven through the **Vercel AI SDK** (`ai` + `@ai-sdk/openai-compatible`) in `src/llm/completion.ts`. Base URL, model, and optional API key come from `aiBaseUrl`, `aiModel`, `aiApiKey`; there is no environment-variable fallback for the key.
 
 Readiness is `isAiReady(settings)` (truthy `aiBaseUrl` + `aiModel`) in `src/llm/completion.ts`. The mentor UI mounts only when `settings.mentorEnabled` is true (`App.tsx`); when off, **Socrates** is hidden from the status bar and `mentorPanelExpanded` is forced closed. When enabled but not ready, `MentorPanel` shows a short setup hint (`t.mentor.needsSetup`) and disables the input until an endpoint is configured. The default points at a local Ollama instance (`http://localhost:11434/v1`, `gemma3:4b`).
 
@@ -28,7 +28,7 @@ On panel open, graph switch, AI-endpoint-readiness change, or **`chatKey`** bump
 
 ## Rendering
 
-Assistant replies render as plain text with subtle emphasis via **`renderWithEmphasis()`** in `emphasis.tsx` (`*asterisks*` → `<em>`). User-authored bubbles remain plain text in a `<span>`.
+Assistant replies render as plain text with subtle emphasis via **`renderWithEmphasis()`** in `emphasis.tsx` (`*asterisks*` → `<em>`). User-authored bubbles remain plain text in a `<span>`. Extracted reasoning is not rendered as content: while `reasoning-delta` is streaming in and no answer text has started, `ThinkingIndicator`'s optional `label` prop shows `t.mentor.thinking` ("thinking…", lowercase, in the body font `var(--font-display)`) next to the loading bars instead of the plain dots. There is no expand affordance for the reasoning text itself yet.
 
 ## Selection vs history
 
@@ -44,12 +44,11 @@ Whether the mentor **sheet** is open is `mentorPanelExpanded` on `useGraphStore`
 
 ## API call
 
-Completions go through **`fetchCompletion()`** in `src/llm/completion.ts`. Pass an optional `AbortSignal`; abort on panel close or graph switch.
+Completions go through **`fetchCompletion()`** in `src/llm/completion.ts`, which calls the SDK's **`streamText`** against a model built by `createOpenAICompatible({ baseURL, apiKey }).chatModel(aiModel)`. It takes a `CompletionRequest` (`{ instructions?, messages }`) as its second argument, plus an optional `AbortSignal` (wired to `streamText`'s `abortSignal`); abort on panel close or graph switch.
 
-`fetchCompletion` posts to `${aiBaseUrl}/chat/completions` with JSON body:
+- `model` — `settings.aiModel`; `apiKey` (→ `Authorization: Bearer …`) only when `settings.aiApiKey` is non-empty.
+- `maxOutputTokens` — `MENTOR_MAX_TOKENS` (~2048; a ceiling, not a target — reply length is soft-capped at ~180 words by the prompt, with headroom for reasoning-model thinking)
+- `instructions` — the system prompt (`buildGraphChatPrompt()`), passed to `streamText`'s `instructions` since the SDK rejects `system` roles inside `messages`.
+- `messages` — the `history` turns mapped to `user` / `assistant` roles (`toConversation`).
 
-- `model` — `settings.aiModel`
-- `max_tokens` — `MENTOR_MAX_TOKENS` (~2048; a ceiling, not a target — reply length is soft-capped at ~180 words by the prompt, with headroom for reasoning-model thinking)
-- `messages` — `[{ role: 'system', content: buildGraphChatPrompt() }, …]` plus full `history` turns mapped to `user` / `assistant` roles.
-
-`Authorization: Bearer …` is sent when `settings.aiApiKey` is non-empty.
+The model is wrapped with **`extractReasoningMiddleware({ tagName: 'think' })`**, so inline `<think>…</think>` (Ollama qwen3, deepseek-r1, …) is split out of the answer. `fetchCompletion` iterates `result.stream` and routes `text-delta` parts to `onToken` and `reasoning-delta` parts to `onReasoning` (an `error` part is rethrown). `isNetworkFailure()` classifies a failure as connection vs HTTP response (`APICallError` without a `statusCode`, or a bare `TypeError`), and `describeCompletionError()` extracts the raw detail (HTTP status + endpoint response body) shown verbatim to the user.

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "build:desktop": "pnpm run icons:desktop && tauri build"
   },
   "dependencies": {
+    "@ai-sdk/openai-compatible": "^3.0.3",
     "@nesso-how/graph": "workspace:*",
     "@nesso-how/schema": "workspace:*",
     "@nesso-how/theme": "workspace:*",
@@ -62,6 +63,7 @@
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",
     "@xyflow/react": "^12.6.4",
+    "ai": "^7.0.11",
     "html-to-image": "^1.11.13",
     "idb": "^8.0.3",
     "posthog-js": "^1.393.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@ai-sdk/openai-compatible':
+        specifier: ^3.0.3
+        version: 3.0.3(zod@4.4.3)
       '@nesso-how/graph':
         specifier: workspace:*
         version: link:packages/graph
@@ -44,6 +47,9 @@ importers:
       '@xyflow/react':
         specifier: ^12.6.4
         version: 12.10.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      ai:
+        specifier: ^7.0.11
+        version: 7.0.11(zod@4.4.3)
       html-to-image:
         specifier: ^1.11.13
         version: 1.11.13
@@ -268,6 +274,28 @@ importers:
         version: 5.8.3
 
 packages:
+
+  '@ai-sdk/gateway@4.0.8':
+    resolution: {integrity: sha512-esHzojMp+LllqOnEu6sYa6NKOmPcE5UObPV61LE6L2QAzCH6WHMgTS+Q/HF5HU3lVUWsHtkDzN7TNqMfv/ecCg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai-compatible@3.0.3':
+    resolution: {integrity: sha512-+mDaUS0q460pVs3oW2/Ps/vj4M2EZnYr1v6ng8TmzxnZPrYBuK7PGQIfckqFdWIdUI/gG8BXcaf8vukLKyGU6Q==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.3':
+    resolution: {integrity: sha512-El0JOXXGcHFe6+owJ1UV0VgB9XtdivP8vcZni+rUIt6lt+cBHCnUdddaA6LE2avJGJ5AD0uXSY+uAvRL2tSvgw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@4.0.1':
+    resolution: {integrity: sha512-6p3C/vGqVIjcptBu1DnVd/BZJ2wWmV9TUv9192vT6ZvT9KNED8EwRTqyqFpoQZKgSbMDSvBSq3dqR524Nt/Crw==}
+    engines: {node: '>=22'}
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -2202,6 +2230,10 @@ packages:
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -2324,6 +2356,9 @@ packages:
     resolution: {integrity: sha512-7S44VrOc7SmJG7TKS9/BbDXHOw2kEHF83uN03gFq7o93BoOdTBoiMfW2dbYSIXpuoh+oq+Ecw0sInob5J2+oUg==}
     engines: {node: '>=18'}
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
   '@xyflow/react@12.10.2':
     resolution: {integrity: sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==}
     peerDependencies:
@@ -2354,6 +2389,12 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ai@7.0.11:
+    resolution: {integrity: sha512-ecCtume1NKJG/8oIkV8G26KL9jmFJRx6+Gjx2260FcDZqIUGPiF1uBoNeGy4S1vxbHmFxUul4D7axqiXZZ1XuA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
@@ -3102,6 +3143,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
@@ -3693,6 +3738,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -5421,6 +5469,31 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@ai-sdk/gateway@4.0.8(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.1
+      '@ai-sdk/provider-utils': 5.0.3(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
+  '@ai-sdk/openai-compatible@3.0.3(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.1
+      '@ai-sdk/provider-utils': 5.0.3(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.3(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.1
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider@4.0.1':
+    dependencies:
+      json-schema: 0.4.0
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -7201,6 +7274,8 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.0
@@ -7466,6 +7541,8 @@ snapshots:
     dependencies:
       '@wdio/logger': 9.18.0
 
+  '@workflow/serde@4.1.0': {}
+
   '@xyflow/react@12.10.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@xyflow/system': 0.0.76
@@ -7502,6 +7579,13 @@ snapshots:
   acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
+
+  ai@7.0.11(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.8(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.1
+      '@ai-sdk/provider-utils': 5.0.3(zod@4.4.3)
+      zod: 4.4.3
 
   ajv@8.18.0:
     dependencies:
@@ -8384,6 +8468,8 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.1.0: {}
+
   execa@9.6.1:
     dependencies:
       '@sindresorhus/merge-streams': 4.0.0
@@ -9138,6 +9224,8 @@ snapshots:
   json-rpc-2.0@1.7.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema@0.4.0: {}
 
   json5@2.2.3: {}
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -132,25 +132,6 @@ fn build_app_menu(
     let export_png_i = MenuItemBuilder::with_id("export-png", &labels.export_png).build(app)?;
     let import_i = MenuItemBuilder::with_id("import", &labels.import).build(app)?;
 
-    let undo_i = MenuItemBuilder::with_id("undo", &labels.undo)
-        .accelerator("CmdOrCtrl+Z")
-        .build(app)?;
-    let redo_i = MenuItemBuilder::with_id("redo", &labels.redo)
-        .accelerator("CmdOrCtrl+Shift+Z")
-        .build(app)?;
-    let cut_i = MenuItemBuilder::with_id("cut", &labels.cut)
-        .accelerator("CmdOrCtrl+X")
-        .build(app)?;
-    let copy_i = MenuItemBuilder::with_id("copy", &labels.copy)
-        .accelerator("CmdOrCtrl+C")
-        .build(app)?;
-    let paste_i = MenuItemBuilder::with_id("paste", &labels.paste)
-        .accelerator("CmdOrCtrl+V")
-        .build(app)?;
-    let select_all_i = MenuItemBuilder::with_id("select-all", &labels.select_all)
-        .accelerator("CmdOrCtrl+A")
-        .build(app)?;
-
     let zoom_in_i = MenuItemBuilder::with_id("zoom-in", &labels.zoom_in)
         .accelerator("CmdOrCtrl+Plus")
         .build(app)?;
@@ -221,15 +202,20 @@ fn build_app_menu(
     let file = file.separator().item(&settings_i);
     let file = file.build()?;
 
-    let edit = SubmenuBuilder::new(app, &labels.edit)
-        .item(&undo_i)
-        .item(&redo_i)
+    let mut edit = SubmenuBuilder::new(app, &labels.edit);
+    #[cfg(target_os = "macos")]
+    {
+        edit = edit
+            .undo_with_text(&labels.undo)
+            .redo_with_text(&labels.redo)
+            .separator();
+    }
+    let edit = edit
+        .cut_with_text(&labels.cut)
+        .copy_with_text(&labels.copy)
+        .paste_with_text(&labels.paste)
         .separator()
-        .item(&cut_i)
-        .item(&copy_i)
-        .item(&paste_i)
-        .separator()
-        .item(&select_all_i)
+        .select_all_with_text(&labels.select_all)
         .build()?;
 
     let edges_sub = SubmenuBuilder::new(app, &labels.edges)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -202,15 +202,13 @@ fn build_app_menu(
     let file = file.separator().item(&settings_i);
     let file = file.build()?;
 
-    let mut edit = SubmenuBuilder::new(app, &labels.edit);
+    let edit_builder = SubmenuBuilder::new(app, &labels.edit);
     #[cfg(target_os = "macos")]
-    {
-        edit = edit
-            .undo_with_text(&labels.undo)
-            .redo_with_text(&labels.redo)
-            .separator();
-    }
-    let edit = edit
+    let edit_builder = edit_builder
+        .undo_with_text(&labels.undo)
+        .redo_with_text(&labels.redo)
+        .separator();
+    let edit = edit_builder
         .cut_with_text(&labels.cut)
         .copy_with_text(&labels.copy)
         .paste_with_text(&labels.paste)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,7 @@ import { CoachmarkOverlay } from './components/onboarding/CoachmarkOverlay'
 import { PALETTES } from '@nesso-how/vocab-learning'
 import { findNewConceptPosition, NEW_CONCEPT_SIZE } from './data/newConceptLayout'
 import { focusFlowNodes } from './lib/focusFlowSelection'
-import { resolveShortcut } from './lib/shortcuts'
+import { resolveShortcut, isTextControlFocused } from './lib/shortcuts'
 import { computeSelectionPan } from './lib/selectionPan'
 import { computeFitViewport, fitCanvasSize } from './lib/fitGraphViewport'
 import { getSeedInitialFitZoom } from './data/seedGraph'
@@ -185,6 +185,16 @@ function AppInner() {
     },
     [getNodes, setViewport, canvasInsets],
   )
+
+  const anyModalOpen =
+    showReview ||
+    showShortcuts ||
+    showSettings ||
+    showRelationTypes ||
+    showSearch ||
+    showAbout ||
+    onboarding.anyModalOpen ||
+    confirmOpen
 
   useDesktopMenu({
     onSettings: () => setShowSettings(true),
@@ -372,18 +382,9 @@ function AppInner() {
   ])
 
   // Keyboard shortcuts
-  const anyModalOpen =
-    showReview ||
-    showShortcuts ||
-    showSettings ||
-    showRelationTypes ||
-    showSearch ||
-    showAbout ||
-    onboarding.anyModalOpen ||
-    confirmOpen
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+      if (isTextControlFocused()) return
       const resolved = resolveShortcut(e, {
         anyModalOpen,
         hasSelectedNode: useGraphStore.getState().selected?.kind === 'node',

--- a/src/components/dialogs/AboutDialog.tsx
+++ b/src/components/dialogs/AboutDialog.tsx
@@ -6,6 +6,7 @@ import {
   APP_VERSION,
   CHANGELOG_URL,
   DOCS_URL,
+  FEEDBACK_URL,
   LICENSE_URL,
   openExternal,
   REPO_URL,
@@ -44,6 +45,7 @@ export function AboutDialog({ open, onClose, onShowTutorial }: Props) {
 
   const links: { label: string; url: string; icon: ReactNode }[] = [
     { label: t.about.links.github, url: REPO_URL, icon: <GithubIcon /> },
+    { label: t.about.links.feedback, url: FEEDBACK_URL, icon: <FeedbackIcon /> },
     { label: t.about.links.website, url: WEBSITE_URL, icon: <GlobeIcon /> },
     { label: t.about.links.documentation, url: DOCS_URL, icon: <BookIcon /> },
     { label: t.about.links.changelog, url: CHANGELOG_URL, icon: <ChangelogIcon /> },
@@ -186,6 +188,23 @@ export function AboutDialog({ open, onClose, onShowTutorial }: Props) {
         </div>
       </div>
     </ModalOverlay>
+  )
+}
+
+function FeedbackIcon() {
+  return (
+    <svg
+      width="15"
+      height="15"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M3 4.5h10a1 1 0 0 1 1 1v5a1 1 0 0 1-1 1H6l-3 2.5V5.5a1 1 0 0 1 1-1z" />
+    </svg>
   )
 }
 

--- a/src/components/inspector/InlineEdit.tsx
+++ b/src/components/inspector/InlineEdit.tsx
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: MIT
 import { useState, useEffect, useLayoutEffect, useRef } from 'react'
 
+function syncScrollHeight(el: HTMLElement) {
+  el.style.height = 'auto'
+  el.style.height = `${el.scrollHeight}px`
+}
+
 export function InlineEdit({
   value,
   placeholder,
@@ -55,19 +60,24 @@ export function InlineEdit({
     if (!editing || !multiline) return
     const el = ref.current as HTMLTextAreaElement | null
     if (!el) return
-    el.style.height = 'auto'
-    el.style.height = `${el.scrollHeight}px`
+    syncScrollHeight(el)
+    const ro = new ResizeObserver(() => syncScrollHeight(el))
+    ro.observe(el)
+    return () => ro.disconnect()
   }, [editing, draft, multiline])
 
   // Snap the display box to the same integer height the textarea computes from
   // scrollHeight, so toggling between display and edit never nudges siblings by
-  // the fractional line-height remainder.
+  // the fractional line-height remainder. ResizeObserver keeps height in sync when
+  // the inspector (or any ancestor) changes width and wrapped line count shifts.
   useLayoutEffect(() => {
     if (editing || !multiline) return
     const el = displayRef.current
     if (!el) return
-    el.style.height = 'auto'
-    el.style.height = `${el.scrollHeight}px`
+    syncScrollHeight(el)
+    const ro = new ResizeObserver(() => syncScrollHeight(el))
+    ro.observe(el)
+    return () => ro.disconnect()
   }, [editing, value, multiline])
 
   const commit = () => {
@@ -136,6 +146,7 @@ export function InlineEdit({
             ...baseStyle,
             overflow: 'hidden',
             resize: 'none',
+            minWidth: 0,
             ...(borderedPlaceholder && { padding: '5px 8px' }),
           } as React.CSSProperties
         }
@@ -199,6 +210,7 @@ export function InlineEdit({
         whiteSpace: multiline ? 'pre-wrap' : 'normal',
         wordBreak: 'break-word',
         minHeight: '1.4em',
+        ...(multiline && { minWidth: 0 }),
         ...(borderedPlaceholder && { padding: '5px 8px' }),
       }}
     >

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -4,7 +4,6 @@ import { useReactFlow, useStore as useFlowStore } from '@xyflow/react'
 import { useGraphStore } from '@/store'
 import { useT } from '@/i18n'
 import { SocratesGlyph } from '@/components/mentor/SocratesGlyph'
-import { FEEDBACK_URL, openExternal } from '@/data/appInfo'
 import { track } from '@/telemetry'
 
 export const STATUS_BAR_HEIGHT_PX = 30
@@ -14,7 +13,7 @@ interface Props {
   onFit: () => void
 }
 
-type IconName = 'undo' | 'redo' | 'minus' | 'plus' | 'fit' | 'feedback'
+type IconName = 'undo' | 'redo' | 'minus' | 'plus' | 'fit'
 
 function StatusIcon({ name }: { name: IconName }) {
   const p = {
@@ -58,12 +57,6 @@ function StatusIcon({ name }: { name: IconName }) {
       return (
         <svg {...p}>
           <path d="M3 6V3h3M13 6V3h-3M3 10v3h3M13 10v3h-3" />
-        </svg>
-      )
-    case 'feedback':
-      return (
-        <svg {...p}>
-          <path d="M3 4.5h10a1 1 0 0 1 1 1v5a1 1 0 0 1-1 1H6l-3 2.5V5.5a1 1 0 0 1 1-1z" />
         </svg>
       )
   }
@@ -236,15 +229,8 @@ export function StatusBar({ sidebarWidth, onFit }: Props) {
         </span>
       </div>
 
-      {/* Right — feedback + history + viewport controls */}
+      {/* Right — history + viewport controls */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-1)', flexShrink: 0 }}>
-        <StatusBtn
-          onClick={() => void openExternal(FEEDBACK_URL)}
-          title={t.statusBar.feedbackTitle}
-        >
-          <StatusIcon name="feedback" />
-        </StatusBtn>
-        <span style={sep} />
         <StatusBtn onClick={undo} disabled={!canUndo} title={t.statusBar.undoTitle}>
           <StatusIcon name="undo" />
         </StatusBtn>

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -177,6 +177,37 @@ const sep: React.CSSProperties = {
   margin: '0 4px',
 }
 
+function ViewportControls({
+  onFit,
+  zoomIn,
+  zoomOut,
+  t,
+}: {
+  onFit: () => void
+  zoomIn: (opts: { duration: number }) => void
+  zoomOut: (opts: { duration: number }) => void
+  t: ReturnType<typeof useT>
+}) {
+  const zoomInAnimated = () => zoomIn({ duration: 200 })
+  const zoomOutAnimated = () => zoomOut({ duration: 200 })
+
+  return (
+    <>
+      <StatusBtn onClick={zoomOutAnimated} title={t.statusBar.zoomOutTitle}>
+        <StatusIcon name="minus" />
+      </StatusBtn>
+      <ZoomReadout />
+      <StatusBtn onClick={zoomInAnimated} title={t.statusBar.zoomInTitle}>
+        <StatusIcon name="plus" />
+      </StatusBtn>
+      <span style={sep} />
+      <StatusBtn onClick={onFit} title={t.statusBar.fitTitle}>
+        <StatusIcon name="fit" />
+      </StatusBtn>
+    </>
+  )
+}
+
 export function StatusBar({ sidebarWidth, onFit }: Props) {
   const t = useT()
   const mentorEnabled = useGraphStore((s) => s.settings.mentorEnabled)
@@ -238,17 +269,7 @@ export function StatusBar({ sidebarWidth, onFit }: Props) {
           <StatusIcon name="redo" />
         </StatusBtn>
         <span style={sep} />
-        <StatusBtn onClick={() => zoomOut({ duration: 200 })} title={t.statusBar.zoomOutTitle}>
-          <StatusIcon name="minus" />
-        </StatusBtn>
-        <ZoomReadout />
-        <StatusBtn onClick={() => zoomIn({ duration: 200 })} title={t.statusBar.zoomInTitle}>
-          <StatusIcon name="plus" />
-        </StatusBtn>
-        <span style={sep} />
-        <StatusBtn onClick={onFit} title={t.statusBar.fitTitle}>
-          <StatusIcon name="fit" />
-        </StatusBtn>
+        <ViewportControls onFit={onFit} zoomIn={zoomIn} zoomOut={zoomOut} t={t} />
       </div>
     </div>
   )

--- a/src/components/mentor/MentorPanel.tsx
+++ b/src/components/mentor/MentorPanel.tsx
@@ -4,7 +4,13 @@ import type { Edge, Node } from '@xyflow/react'
 import { SocratesGlyph } from './SocratesGlyph'
 import { useGraphStore, selectedNodeSelector, selectedEdgeSelector } from '@/store'
 import type { ConceptNodeData, Language } from '@/types/graph'
-import { fetchCompletion, isAiReady } from '@/llm/completion'
+import type { ChatMessage } from '@/llm/completion'
+import {
+  describeCompletionError,
+  fetchCompletion,
+  isAiReady,
+  isNetworkFailure,
+} from '@/llm/completion'
 import { buildFocalNeighborContext, nodeStrength, oneHopNeighborIds } from '@/llm/context'
 import { useT } from '@/i18n'
 import { CloseButton } from '@/components/ui/CloseButton'
@@ -16,32 +22,32 @@ import { track } from '@/telemetry'
 interface Message {
   role: 'user' | 'mentor'
   text: string
+  /** Rendered as a technical error rather than a Socrates reply. */
+  error?: boolean
 }
 
-/** Coarse failure category for telemetry: a fetch network/CORS failure throws TypeError; an HTTP error does not. */
-function mentorFailureReason(err: unknown): 'network' | 'response' {
-  return err instanceof TypeError ? 'network' : 'response'
-}
-
+/**
+ * The mentor is experimental and its users are technical, so surface the real error.
+ * A connection failure keeps the actionable hint (check Settings, run `ollama serve`)
+ * with the raw detail appended; other failures show the detail alone.
+ */
 function mentorFailureMessage(err: unknown, t: ReturnType<typeof useT>): string {
-  if (err instanceof TypeError) return t.mentor.errorConnection
-  return t.mentor.errorRetrySlow
+  const detail = describeCompletionError(err)
+  return isNetworkFailure(err) ? `${t.mentor.errorConnection}\n\n${detail}` : detail
 }
 
+/** Grows the last mentor bubble (or starts one) with an answer delta. */
 function appendToLastMentor(history: Message[], delta: string): Message[] {
   const last = history[history.length - 1]
   if (!last || last.role !== 'mentor') return [...history, { role: 'mentor', text: delta }]
   return [...history.slice(0, -1), { ...last, text: last.text + delta }]
 }
 
-function mentorCompletionMessages(systemPrompt: string, msgs: Message[]) {
-  return [
-    { role: 'system' as const, content: systemPrompt },
-    ...msgs.map((m) => ({
-      role: m.role === 'user' ? ('user' as const) : ('assistant' as const),
-      content: m.text,
-    })),
-  ]
+function toConversation(msgs: Message[]): ChatMessage[] {
+  return msgs.map((m) => ({
+    role: m.role === 'user' ? ('user' as const) : ('assistant' as const),
+    content: m.text,
+  }))
 }
 
 /** Cap snapshot size so the system prompt stays bounded on large graphs. */
@@ -195,6 +201,8 @@ export function MentorPanel({ leftInset, rightInset }: { leftInset: number; righ
   const [thinking, setThinking] = useState(false)
   const [streaming, setStreaming] = useState(false)
   const [loadingInitial, setLoadingInitial] = useState(false)
+  /** True once reasoning deltas are streaming in but the answer hasn't started yet. */
+  const [reasoningActive, setReasoningActive] = useState(false)
   const [chatKey, setChatKey] = useState(0)
 
   const inputRef = useRef<HTMLTextAreaElement>(null)
@@ -227,6 +235,7 @@ export function MentorPanel({ leftInset, rightInset }: { leftInset: number; righ
     setHistory([])
     setStreaming(false)
     setLoadingInitial(true)
+    setReasoningActive(false)
 
     const storeState = useGraphStore.getState()
     const systemPrompt = buildSystemPrompt()
@@ -237,33 +246,42 @@ export function MentorPanel({ leftInset, rightInset }: { leftInset: number; righ
       selectedEdgeSelector(storeState),
     )
 
-    let started = false
+    let answered = false
     fetchCompletion(
       settings,
-      mentorCompletionMessages(systemPrompt, [{ role: 'user', text: seedText }]),
+      { instructions: systemPrompt, messages: [{ role: 'user', content: seedText }] },
       MENTOR_MAX_TOKENS,
       controller.signal,
-      (delta) => {
-        if (controller.signal.aborted) return
-        if (!started) {
-          started = true
-          setLoadingInitial(false)
-          setStreaming(true)
-          setHistory([{ role: 'mentor', text: delta }])
-        } else {
+      {
+        onToken: (delta) => {
+          if (controller.signal.aborted) return
+          if (!answered) {
+            answered = true
+            setLoadingInitial(false)
+            setReasoningActive(false)
+            setStreaming(true)
+          }
           setHistory((h) => appendToLastMentor(h, delta))
-        }
+        },
+        onReasoning: () => {
+          if (controller.signal.aborted) return
+          setReasoningActive(true)
+        },
       },
     )
       .then((full) => {
-        if (!controller.signal.aborted && !started) {
-          setHistory([{ role: 'mentor', text: full || '…' }])
+        if (!controller.signal.aborted && !answered) {
+          setReasoningActive(false)
+          setHistory((h) => appendToLastMentor(h, full || '…'))
         }
       })
       .catch((err) => {
         if (!controller.signal.aborted) {
-          setHistory([{ role: 'mentor', text: mentorFailureMessage(err, t) }])
-          track({ name: 'mentor_request_failed', props: { reason: mentorFailureReason(err) } })
+          setHistory([{ role: 'mentor', text: mentorFailureMessage(err, t), error: true }])
+          track({
+            name: 'mentor_request_failed',
+            props: { reason: isNetworkFailure(err) ? 'network' : 'response' },
+          })
         }
       })
       .finally(() => {
@@ -303,38 +321,51 @@ export function MentorPanel({ leftInset, rightInset }: { leftInset: number; righ
     setHistory(next)
     setDraft('')
     setThinking(true)
+    setReasoningActive(false)
     track({ name: 'mentor_message_sent' })
     requestAnimationFrame(() => {
       const el = scrollRef.current
       if (el) el.scrollTop = el.scrollHeight
     })
-    let started = false
+    let answered = false
     try {
       const full = await fetchCompletion(
         settings,
-        mentorCompletionMessages(buildSystemPrompt(), next),
+        { instructions: buildSystemPrompt(), messages: toConversation(next) },
         MENTOR_MAX_TOKENS,
         controller.signal,
-        (delta) => {
-          if (controller.signal.aborted) return
-          if (!started) {
-            started = true
-            setThinking(false)
-            setStreaming(true)
-            setHistory((h) => [...h, { role: 'mentor', text: delta }])
-          } else {
+        {
+          onToken: (delta) => {
+            if (controller.signal.aborted) return
+            if (!answered) {
+              answered = true
+              setThinking(false)
+              setReasoningActive(false)
+              setStreaming(true)
+            }
             setHistory((h) => appendToLastMentor(h, delta))
-          }
+          },
+          onReasoning: () => {
+            if (controller.signal.aborted) return
+            setReasoningActive(true)
+          },
         },
       )
-      if (!controller.signal.aborted && !started) {
-        setHistory((h) => [...h, { role: 'mentor', text: full || '…' }])
+      if (!controller.signal.aborted && !answered) {
+        setReasoningActive(false)
+        setHistory((h) => appendToLastMentor(h, full || '…'))
       }
       if (!controller.signal.aborted) track({ name: 'mentor_response_received' })
     } catch (err) {
       if (!controller.signal.aborted) {
-        setHistory((h) => [...h, { role: 'mentor', text: mentorFailureMessage(err, t) }])
-        track({ name: 'mentor_request_failed', props: { reason: mentorFailureReason(err) } })
+        setHistory((h) => [
+          ...h,
+          { role: 'mentor', text: mentorFailureMessage(err, t), error: true },
+        ])
+        track({
+          name: 'mentor_request_failed',
+          props: { reason: isNetworkFailure(err) ? 'network' : 'response' },
+        })
       }
     } finally {
       if (!controller.signal.aborted) setStreaming(false)
@@ -420,7 +451,7 @@ export function MentorPanel({ leftInset, rightInset }: { leftInset: number; righ
           </div>
           <button
             type="button"
-            title={settings.language === 'it' ? 'Nuova chat' : 'New chat'}
+            title={t.mentor.newChat}
             disabled={loadingInitial || thinking}
             onClick={() => setChatKey((k) => k + 1)}
             style={{
@@ -478,7 +509,7 @@ export function MentorPanel({ leftInset, rightInset }: { leftInset: number; righ
           }}
         >
           {loadingInitial && history.length === 0 ? (
-            <ThinkingIndicator />
+            <ThinkingIndicator label={reasoningActive ? t.mentor.thinking : undefined} />
           ) : (
             history.map((m, i) =>
               m.role === 'user' ? (
@@ -505,6 +536,25 @@ export function MentorPanel({ leftInset, rightInset }: { leftInset: number; righ
                   >
                     {m.text}
                   </span>
+                </div>
+              ) : m.error ? (
+                <div
+                  key={i}
+                  style={{
+                    fontSize: '12px',
+                    fontWeight: 400,
+                    lineHeight: 1.5,
+                    fontFamily: 'var(--font-mono)',
+                    color: 'var(--ink-3)',
+                    whiteSpace: 'pre-wrap',
+                    wordBreak: 'break-word',
+                    margin: '5px 0',
+                    padding: '8px 10px',
+                    background: 'var(--paper-deep)',
+                    borderRadius: 'var(--radius-md)',
+                  }}
+                >
+                  {m.text}
                 </div>
               ) : (
                 <div
@@ -538,7 +588,9 @@ export function MentorPanel({ leftInset, rightInset }: { leftInset: number; righ
               ),
             )
           )}
-          {thinking && <ThinkingIndicator />}
+          {thinking && (
+            <ThinkingIndicator label={reasoningActive ? t.mentor.thinking : undefined} />
+          )}
         </div>
 
         <div

--- a/src/components/mentor/MentorPanel.tsx
+++ b/src/components/mentor/MentorPanel.tsx
@@ -43,6 +43,103 @@ function appendToLastMentor(history: Message[], delta: string): Message[] {
   return [...history.slice(0, -1), { ...last, text: last.text + delta }]
 }
 
+function MentorUserBubble({ text }: { text: string }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'flex-end', margin: '5px 0' }}>
+      <span
+        style={{
+          fontSize: '13px',
+          fontWeight: 500,
+          lineHeight: 1.45,
+          fontFamily: 'var(--font-sans)',
+          color: 'var(--ink-2)',
+          padding: '7px 11px',
+          background: 'var(--paper-deep)',
+          borderRadius: 'var(--radius-lg) var(--radius-lg) var(--radius-sm) var(--radius-lg)',
+          marginLeft: 36,
+          border: '0.5px solid var(--line)',
+          display: 'inline-block',
+          maxWidth: '100%',
+        }}
+      >
+        {text}
+      </span>
+    </div>
+  )
+}
+
+function MentorErrorBubble({ text }: { text: string }) {
+  return (
+    <div
+      style={{
+        fontSize: '12px',
+        fontWeight: 400,
+        lineHeight: 1.5,
+        fontFamily: 'var(--font-mono)',
+        color: 'var(--ink-3)',
+        whiteSpace: 'pre-wrap',
+        wordBreak: 'break-word',
+        margin: '5px 0',
+        padding: '8px 10px',
+        background: 'var(--paper-deep)',
+        borderRadius: 'var(--radius-md)',
+      }}
+    >
+      {text}
+    </div>
+  )
+}
+
+function MentorReplyBubble({ text, showCaret }: { text: string; showCaret: boolean }) {
+  return (
+    <div
+      style={{
+        fontSize: '14.5px',
+        fontWeight: 400,
+        lineHeight: 1.45,
+        fontFamily: 'var(--font-display)',
+        color: 'var(--ink)',
+        letterSpacing: '-0.005em',
+        margin: '5px 0',
+        whiteSpace: 'pre-wrap',
+      }}
+    >
+      {renderWithEmphasis(text)}
+      {showCaret && (
+        <span
+          style={{
+            display: 'inline-block',
+            width: 1.5,
+            height: '0.95em',
+            background: 'var(--ink-3)',
+            marginLeft: 2,
+            verticalAlign: 'text-bottom',
+            animation: 'nx-tw-caret 0.85s steps(2, end) infinite',
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+function MentorChatMessage({
+  message,
+  index,
+  historyLength,
+  streaming,
+}: {
+  message: Message
+  index: number
+  historyLength: number
+  streaming: boolean
+}) {
+  if (message.role === 'user') return <MentorUserBubble text={message.text} />
+  if (message.error) return <MentorErrorBubble text={message.text} />
+  return (
+    <MentorReplyBubble text={message.text} showCaret={streaming && index === historyLength - 1} />
+  )
+}
+
 function toConversation(msgs: Message[]): ChatMessage[] {
   return msgs.map((m) => ({
     role: m.role === 'user' ? ('user' as const) : ('assistant' as const),
@@ -511,82 +608,15 @@ export function MentorPanel({ leftInset, rightInset }: { leftInset: number; righ
           {loadingInitial && history.length === 0 ? (
             <ThinkingIndicator label={reasoningActive ? t.mentor.thinking : undefined} />
           ) : (
-            history.map((m, i) =>
-              m.role === 'user' ? (
-                <div
-                  key={i}
-                  style={{ display: 'flex', justifyContent: 'flex-end', margin: '5px 0' }}
-                >
-                  <span
-                    style={{
-                      fontSize: '13px',
-                      fontWeight: 500,
-                      lineHeight: 1.45,
-                      fontFamily: 'var(--font-sans)',
-                      color: 'var(--ink-2)',
-                      padding: '7px 11px',
-                      background: 'var(--paper-deep)',
-                      borderRadius:
-                        'var(--radius-lg) var(--radius-lg) var(--radius-sm) var(--radius-lg)',
-                      marginLeft: 36,
-                      border: '0.5px solid var(--line)',
-                      display: 'inline-block',
-                      maxWidth: '100%',
-                    }}
-                  >
-                    {m.text}
-                  </span>
-                </div>
-              ) : m.error ? (
-                <div
-                  key={i}
-                  style={{
-                    fontSize: '12px',
-                    fontWeight: 400,
-                    lineHeight: 1.5,
-                    fontFamily: 'var(--font-mono)',
-                    color: 'var(--ink-3)',
-                    whiteSpace: 'pre-wrap',
-                    wordBreak: 'break-word',
-                    margin: '5px 0',
-                    padding: '8px 10px',
-                    background: 'var(--paper-deep)',
-                    borderRadius: 'var(--radius-md)',
-                  }}
-                >
-                  {m.text}
-                </div>
-              ) : (
-                <div
-                  key={i}
-                  style={{
-                    fontSize: '14.5px',
-                    fontWeight: 400,
-                    lineHeight: 1.45,
-                    fontFamily: 'var(--font-display)',
-                    color: 'var(--ink)',
-                    letterSpacing: '-0.005em',
-                    margin: '5px 0',
-                    whiteSpace: 'pre-wrap',
-                  }}
-                >
-                  {renderWithEmphasis(m.text)}
-                  {streaming && i === history.length - 1 && (
-                    <span
-                      style={{
-                        display: 'inline-block',
-                        width: 1.5,
-                        height: '0.95em',
-                        background: 'var(--ink-3)',
-                        marginLeft: 2,
-                        verticalAlign: 'text-bottom',
-                        animation: 'nx-tw-caret 0.85s steps(2, end) infinite',
-                      }}
-                    />
-                  )}
-                </div>
-              ),
-            )
+            history.map((m, i) => (
+              <MentorChatMessage
+                key={i}
+                message={m}
+                index={i}
+                historyLength={history.length}
+                streaming={streaming}
+              />
+            ))
           )}
           {thinking && (
             <ThinkingIndicator label={reasoningActive ? t.mentor.thinking : undefined} />

--- a/src/components/mentor/ThinkingIndicator.tsx
+++ b/src/components/mentor/ThinkingIndicator.tsx
@@ -2,32 +2,47 @@
 
 const BARS = [0, 120, 240, 360]
 
-export function ThinkingIndicator() {
+/** `label` (e.g. "thinking…") renders to the right once reasoning starts streaming. */
+export function ThinkingIndicator({ label }: { label?: string } = {}) {
   return (
-    <div
-      style={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        gap: 5,
-        height: 22,
-        padding: '4px 0',
-        flexShrink: 0,
-      }}
-    >
-      {BARS.map((delay) => (
+    <div style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+      <div
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 4,
+          height: 14,
+          padding: '4px 0',
+          flexShrink: 0,
+        }}
+      >
+        {BARS.map((delay) => (
+          <span
+            key={delay}
+            style={{
+              display: 'inline-block',
+              width: 2,
+              height: '100%',
+              borderRadius: 'var(--radius-sm)',
+              background: 'var(--ink-3)',
+              transformOrigin: 'center',
+              animation: `nx-bars 1.1s cubic-bezier(0.45, 0, 0.55, 1) ${delay}ms infinite`,
+            }}
+          />
+        ))}
+      </div>
+      {label && (
         <span
-          key={delay}
           style={{
-            display: 'inline-block',
-            width: 2,
-            height: '100%',
-            borderRadius: 'var(--radius-sm)',
-            background: 'var(--ink-3)',
-            transformOrigin: 'center',
-            animation: `nx-bars 1.1s cubic-bezier(0.45, 0, 0.55, 1) ${delay}ms infinite`,
+            fontSize: '13px',
+            fontFamily: 'var(--font-display)',
+            color: 'var(--ink-4)',
+            letterSpacing: '-0.005em',
           }}
-        />
-      ))}
+        >
+          {label}
+        </span>
+      )}
     </div>
   )
 }

--- a/src/components/review/ReviewMode.tsx
+++ b/src/components/review/ReviewMode.tsx
@@ -7,6 +7,7 @@ import { useGraphStore } from '@/store'
 import { nodeToCard, type RelationTypeName } from '@/types/graph'
 import { ratingColor } from '@nesso-how/graph'
 import { useT } from '@/i18n'
+import { isTextControlFocused } from '@/lib/shortcuts'
 import { CloseButton } from '@/components/ui/CloseButton'
 import { ModalOverlay } from '@/components/ui/ModalOverlay'
 import { track } from '@/telemetry'
@@ -540,7 +541,7 @@ function ReviewKeyHandler({
   useEffect(() => {
     if (!open) return
     const onKey = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+      if (isTextControlFocused()) return
       if (!revealedRef.current && (e.key === ' ' || e.key === 'Enter')) {
         e.preventDefault()
         onRevealRef.current()

--- a/src/hooks/useDesktopMenu.ts
+++ b/src/hooks/useDesktopMenu.ts
@@ -6,7 +6,6 @@ import { useT, getT } from '@/i18n'
 import { isDesktop } from '@/lib/isDesktop'
 import { applyDesktopMenu } from '@/lib/desktopMenu'
 import { exportGraphJson, exportGraphPng, importGraphFile } from '@/lib/graphIO'
-import { focusFlowNodes } from '@/lib/focusFlowSelection'
 import { openExternal, DOCS_URL, WEBSITE_URL, FEEDBACK_URL } from '@/data/appInfo'
 
 interface DesktopMenuHandlers {
@@ -57,16 +56,6 @@ export function useDesktopMenu(handlers: DesktopMenuHandlers): void {
       await on('export-json', () => void exportGraphJson())
       await on('export-png', () => void exportGraphPng())
       await on('import', () => importGraphFile())
-
-      await on('undo', () => store().undo())
-      await on('redo', () => store().redo())
-      await on('cut', () => store().cutSelection())
-      await on('copy', () => store().copySelection())
-      await on('paste', () => {
-        const ids = store().pasteSelection()
-        if (ids?.length) focusFlowNodes(ids)
-      })
-      await on('select-all', () => store().selectAll())
 
       await on('heatmap', () =>
         store().setGraphDisplay('showHeatmap', !store().graphDisplay.showHeatmap),

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -273,7 +273,6 @@ const en = {
     zoomOutTitle: 'Zoom out',
     zoomInTitle: 'Zoom in',
     fitTitle: 'Center / fit (F)',
-    feedbackTitle: 'Send feedback',
   },
   contextMenu: {
     copy: 'Copy',
@@ -383,6 +382,7 @@ const en = {
     version: (v: string) => `v${v}`,
     links: {
       github: 'GitHub',
+      feedback: 'Send feedback',
       website: 'Website',
       documentation: 'Documentation',
       changelog: 'Changelog',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -401,8 +401,8 @@ const en = {
     placeholderNeedsSetup: 'Configure an AI endpoint in Settings first…',
     errorConnection:
       "Can't reach the AI endpoint. Check Settings (⌘,) → AI. For local Ollama, run `ollama serve`.",
-    errorRetry: '*Hmm.* My voice failed me. Try again.',
-    errorRetrySlow: '*Hmm.* My voice failed me. Try again, slowly.',
+    newChat: 'New chat',
+    thinking: 'thinking…',
   },
   menu: {
     file: 'File',

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -402,8 +402,8 @@ const it: typeof en = {
     placeholderNeedsSetup: 'Configura prima un endpoint AI in Impostazioni…',
     errorConnection:
       "Non riesco a raggiungere l'endpoint AI. Controlla Impostazioni (⌘,) → AI. In locale, avvia `ollama serve`.",
-    errorRetry: '*Hmm.* La mia voce mi ha tradito. Riprova.',
-    errorRetrySlow: '*Hmm.* La mia voce mi ha tradito. Riprova, lentamente.',
+    newChat: 'Nuova chat',
+    thinking: 'sto pensando…',
   },
   menu: {
     file: 'File',

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -274,7 +274,6 @@ const it: typeof en = {
     zoomOutTitle: 'Riduci zoom',
     zoomInTitle: 'Aumenta zoom',
     fitTitle: 'Centra / adatta (F)',
-    feedbackTitle: 'Invia feedback',
   },
   contextMenu: {
     copy: 'Copia',
@@ -384,6 +383,7 @@ const it: typeof en = {
     version: (v) => `v${v}`,
     links: {
       github: 'GitHub',
+      feedback: 'Invia feedback',
       website: 'Sito web',
       documentation: 'Documentazione',
       changelog: 'Changelog',

--- a/src/lib/shortcuts.test.ts
+++ b/src/lib/shortcuts.test.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
+/** @vitest-environment jsdom */
 import { describe, expect, it } from 'vitest'
-import { resolveShortcut, type ShortcutKey } from './shortcuts'
+import { resolveShortcut, isTextControlFocused, type ShortcutKey } from './shortcuts'
 
 const key = (over: Partial<ShortcutKey> & { key: string }): ShortcutKey => ({
   metaKey: false,
@@ -89,5 +90,29 @@ describe('resolveShortcut', () => {
 
   it('returns null for unmapped keys', () => {
     expect(resolveShortcut(key({ key: 'q' }), NO_MODAL)).toBeNull()
+  })
+})
+
+describe('isTextControlFocused', () => {
+  it('is true for focused input and textarea elements', () => {
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    input.focus()
+    expect(isTextControlFocused()).toBe(true)
+    input.remove()
+  })
+
+  it('is true for readonly inputs', () => {
+    const input = document.createElement('input')
+    input.readOnly = true
+    document.body.appendChild(input)
+    input.focus()
+    expect(isTextControlFocused()).toBe(true)
+    input.remove()
+  })
+
+  it('is false when focus is on the document body', () => {
+    document.body.focus()
+    expect(isTextControlFocused()).toBe(false)
   })
 })

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -40,8 +40,16 @@ export interface ResolvedShortcut {
   preventDefault: boolean
 }
 
+/** True when a text control has focus and graph shortcuts should not run. */
+export function isTextControlFocused(): boolean {
+  const el = document.activeElement
+  if (!el) return false
+  if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) return true
+  return Boolean(el instanceof HTMLElement && el.isContentEditable)
+}
+
 /**
- * Map a keydown to a canvas action. Pure: the caller guards editable targets,
+ * Map a keydown to a canvas action. Pure: the caller guards text-control focus,
  * applies `preventDefault`, and dispatches the returned action against the store.
  * Returns null when the key is not a shortcut (or is suppressed by a modal).
  */

--- a/src/llm/completion.test.ts
+++ b/src/llm/completion.test.ts
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
+import { APICallError } from 'ai'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { NessoSettings } from '@/types/graph'
-import { fetchCompletion, isAiReady } from './completion'
+import { describeCompletionError, fetchCompletion, isAiReady, isNetworkFailure } from './completion'
 
 const settings = {
   aiBaseUrl: 'http://localhost:11434/v1',
@@ -9,20 +10,34 @@ const settings = {
   aiApiKey: '',
 } as unknown as NessoSettings
 
-function sseResponse(chunks: string[]): Response {
+/** One OpenAI-compatible SSE chunk carrying a content delta. */
+function chunk(content: string): string {
+  return `data: ${JSON.stringify({
+    id: '1',
+    object: 'chat.completion.chunk',
+    choices: [{ index: 0, delta: { content } }],
+  })}\n\n`
+}
+
+function sseResponse(contents: string[]): Response {
   const encoder = new TextEncoder()
+  const stop = `data: ${JSON.stringify({
+    id: '1',
+    object: 'chat.completion.chunk',
+    choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+  })}\n\n`
   const stream = new ReadableStream<Uint8Array>({
     start(controller) {
-      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk))
+      for (const c of contents) controller.enqueue(encoder.encode(chunk(c)))
+      controller.enqueue(encoder.encode(stop))
+      controller.enqueue(encoder.encode('data: [DONE]\n\n'))
       controller.close()
     },
   })
-  return new Response(stream, { status: 200 })
-}
-
-function sentBody(mock: ReturnType<typeof vi.fn>): { stream?: boolean } {
-  const init = mock.mock.calls[0]?.[1] as RequestInit | undefined
-  return JSON.parse((init?.body as string | undefined) ?? '{}')
+  return new Response(stream, {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream' },
+  })
 }
 
 afterEach(() => vi.restoreAllMocks())
@@ -35,72 +50,101 @@ describe('isAiReady', () => {
   })
 })
 
-describe('fetchCompletion streaming (onToken)', () => {
-  it('forwards each SSE delta and returns the concatenation', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(
-        sseResponse([
-          'data: {"choices":[{"delta":{"content":"Hel"}}]}\n',
-          'data: {"choices":[{"delta":{"content":"lo"}}]}\n\n',
-          'data: [DONE]\n',
-        ]),
-      )
-    vi.stubGlobal('fetch', fetchMock)
-
-    const tokens: string[] = []
-    const full = await fetchCompletion(
-      settings,
-      [{ role: 'user', content: 'hi' }],
-      100,
-      undefined,
-      (delta) => tokens.push(delta),
-    )
-
-    expect(tokens).toEqual(['Hel', 'lo'])
-    expect(full).toBe('Hello')
-    expect(sentBody(fetchMock).stream).toBe(true)
+describe('isNetworkFailure', () => {
+  it('flags a connection error (APICallError without status) as network', () => {
+    const err = new APICallError({
+      message: 'fetch failed',
+      url: 'http://x/v1/chat/completions',
+      requestBodyValues: {},
+      isRetryable: true,
+    })
+    expect(isNetworkFailure(err)).toBe(true)
   })
 
-  it('reassembles a data line split across chunks', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(
-        sseResponse(['data: {"choices":[{"delta":{"con', 'tent":"X"}}]}\n', 'data: [DONE]\n']),
-      )
-    vi.stubGlobal('fetch', fetchMock)
+  it('flags an HTTP response error (APICallError with status) as non-network', () => {
+    const err = new APICallError({
+      message: 'server error',
+      url: 'http://x/v1/chat/completions',
+      requestBodyValues: {},
+      statusCode: 500,
+      isRetryable: false,
+    })
+    expect(isNetworkFailure(err)).toBe(false)
+  })
 
-    const tokens: string[] = []
-    const full = await fetchCompletion(
-      settings,
-      [{ role: 'user', content: 'hi' }],
-      100,
-      undefined,
-      (delta) => tokens.push(delta),
-    )
-
-    expect(full).toBe('X')
-    expect(tokens).toEqual(['X'])
+  it('treats a bare TypeError as network and other errors as non-network', () => {
+    expect(isNetworkFailure(new TypeError('Failed to fetch'))).toBe(true)
+    expect(isNetworkFailure(new Error('parse'))).toBe(false)
   })
 })
 
-describe('fetchCompletion non-streaming (no onToken)', () => {
-  it('returns the message content and omits the stream flag', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ choices: [{ message: { content: 'done' } }] }), {
-        status: 200,
-      }),
-    )
-    vi.stubGlobal('fetch', fetchMock)
-
-    const full = await fetchCompletion(settings, [{ role: 'user', content: 'hi' }], 100)
-
-    expect(full).toBe('done')
-    expect(sentBody(fetchMock).stream).toBeUndefined()
+describe('describeCompletionError', () => {
+  it('prefers the SDK-parsed message over the raw JSON response body', () => {
+    const err = new APICallError({
+      message: "model 'x' not found",
+      url: 'http://x/v1/chat/completions',
+      requestBodyValues: {},
+      statusCode: 404,
+      responseBody: '{"error":{"message":"model \'x\' not found","type":"not_found_error"}}',
+      isRetryable: false,
+    })
+    expect(describeCompletionError(err)).toBe("HTTP 404: model 'x' not found")
   })
 
-  it('throws when the response is not ok', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('boom', { status: 500 })))
-    await expect(fetchCompletion(settings, [], 100)).rejects.toThrow('boom')
+  it('falls back to the error name when there is no HTTP status', () => {
+    const err = new APICallError({
+      message: 'fetch failed',
+      url: 'http://x/v1/chat/completions',
+      requestBodyValues: {},
+      isRetryable: true,
+    })
+    expect(describeCompletionError(err)).toBe('AI_APICallError: fetch failed')
+  })
+
+  it('shows name and message for a plain error, and stringifies non-errors', () => {
+    expect(describeCompletionError(new TypeError('boom'))).toBe('TypeError: boom')
+    expect(describeCompletionError('boom')).toBe('boom')
+  })
+})
+
+describe('fetchCompletion streaming', () => {
+  it('forwards answer tokens and returns their concatenation, with a system prompt', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(sseResponse(['Hel', 'lo'])))
+
+    const tokens: string[] = []
+    const full = await fetchCompletion(
+      settings,
+      { instructions: 'You are Socrates.', messages: [{ role: 'user', content: 'hi' }] },
+      100,
+      undefined,
+      { onToken: (delta) => tokens.push(delta) },
+    )
+
+    expect(tokens.join('')).toBe('Hello')
+    expect(full).toBe('Hello')
+  })
+
+  it('splits inline <think> reasoning out of the answer', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(sseResponse(['<think>', 'because', '</think>', 'Hello'])),
+    )
+
+    const answer: string[] = []
+    const reasoning: string[] = []
+    const full = await fetchCompletion(
+      settings,
+      { instructions: 'You are Socrates.', messages: [{ role: 'user', content: 'hi' }] },
+      100,
+      undefined,
+      {
+        onToken: (delta) => answer.push(delta),
+        onReasoning: (delta) => reasoning.push(delta),
+      },
+    )
+
+    expect(full.trim()).toBe('Hello')
+    expect(answer.join('')).not.toContain('<think>')
+    expect(reasoning.join('')).toContain('because')
   })
 })

--- a/src/llm/completion.ts
+++ b/src/llm/completion.ts
@@ -1,79 +1,90 @@
 // SPDX-License-Identifier: MIT
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
+import { APICallError, extractReasoningMiddleware, streamText, wrapLanguageModel } from 'ai'
 import type { NessoSettings } from '@/types/graph'
 
-type Message = { role: 'system' | 'user' | 'assistant'; content: string }
+/** A chat turn. The system prompt is passed separately as `instructions`, never as a role here. */
+export type ChatMessage = { role: 'user' | 'assistant'; content: string }
+
+/** A completion request: the system prompt (`instructions`) plus the user/assistant turns. */
+export interface CompletionRequest {
+  instructions?: string
+  messages: ChatMessage[]
+}
+
+/** Callbacks for the streamed response: `onToken` gets the clean answer, `onReasoning` the model's thinking. */
+export interface CompletionHandlers {
+  onToken?: (delta: string) => void
+  onReasoning?: (delta: string) => void
+}
 
 export function isAiReady(settings: NessoSettings): boolean {
   return Boolean(settings.aiBaseUrl && settings.aiModel)
 }
 
-/** Extracts the assistant text delta from one SSE line, or null for keepalive / `[DONE]` / unparseable lines. */
-function sseLineDelta(line: string): string | null {
-  const trimmed = line.trim()
-  if (!trimmed.startsWith('data:')) return null
-  const payload = trimmed.slice(5).trim()
-  if (payload === '[DONE]') return null
-  try {
-    const json = JSON.parse(payload) as { choices?: { delta?: { content?: string | null } }[] }
-    return json.choices?.[0]?.delta?.content ?? null
-  } catch {
-    return null
-  }
+/**
+ * Wraps the configured OpenAI-compatible endpoint with reasoning extraction so
+ * inline `<think>…</think>` (Ollama qwen3, deepseek-r1, …) is split out of the
+ * answer into a separate `reasoning-delta` stream instead of leaking into the reply.
+ */
+function mentorModel(settings: NessoSettings) {
+  const provider = createOpenAICompatible({
+    name: 'nesso-mentor',
+    baseURL: settings.aiBaseUrl.replace(/\/+$/, ''),
+    ...(settings.aiApiKey ? { apiKey: settings.aiApiKey } : {}),
+  })
+  return wrapLanguageModel({
+    model: provider.chatModel(settings.aiModel),
+    middleware: extractReasoningMiddleware({ tagName: 'think' }),
+  })
 }
 
-async function readSseStream(
-  body: ReadableStream<Uint8Array>,
-  onToken: (delta: string) => void,
-): Promise<string> {
-  const reader = body.getReader()
-  const decoder = new TextDecoder()
-  let buffer = ''
-  let full = ''
-  try {
-    while (true) {
-      const { done, value } = await reader.read()
-      if (done) break
-      buffer += decoder.decode(value, { stream: true })
-      const lines = buffer.split('\n')
-      buffer = lines.pop() ?? ''
-      for (const line of lines) {
-        const delta = sseLineDelta(line)
-        if (delta) {
-          full += delta
-          onToken(delta)
-        }
-      }
-    }
-  } finally {
-    reader.releaseLock()
+/** True when the failure is a connection/CORS error rather than an HTTP response error. */
+export function isNetworkFailure(err: unknown): boolean {
+  if (APICallError.isInstance(err)) return err.statusCode === undefined
+  return err instanceof TypeError
+}
+
+/**
+ * Human-readable technical detail for a failed completion, shown verbatim to the
+ * (technical) user as `<type>: <message>`. For an API error the SDK already parses
+ * the endpoint's JSON error body into `message` (e.g. `model 'x' not found`), so this
+ * uses that directly rather than the raw response body.
+ */
+export function describeCompletionError(err: unknown): string {
+  if (APICallError.isInstance(err)) {
+    const type = err.statusCode ? `HTTP ${err.statusCode}` : err.name
+    return `${type}: ${err.message}`
   }
-  return full
+  if (err instanceof Error) return `${err.name}: ${err.message}`
+  return String(err)
 }
 
 export async function fetchCompletion(
   settings: NessoSettings,
-  messages: Message[],
+  request: CompletionRequest,
   maxTokens: number,
   signal?: AbortSignal,
-  onToken?: (delta: string) => void,
+  handlers?: CompletionHandlers,
 ): Promise<string> {
-  const baseUrl = settings.aiBaseUrl.replace(/\/+$/, '')
-  const res = await fetch(`${baseUrl}/chat/completions`, {
-    method: 'POST',
-    signal,
-    headers: {
-      'Content-Type': 'application/json',
-      ...(settings.aiApiKey ? { Authorization: `Bearer ${settings.aiApiKey}` } : {}),
-    },
-    body: JSON.stringify({
-      model: settings.aiModel,
-      max_tokens: maxTokens,
-      messages,
-      ...(onToken ? { stream: true } : {}),
-    }),
+  // The SDK takes the system prompt as `instructions`, not a `system` role in `messages`.
+  const result = streamText({
+    model: mentorModel(settings),
+    ...(request.instructions ? { instructions: request.instructions } : {}),
+    messages: request.messages,
+    maxOutputTokens: maxTokens,
+    abortSignal: signal,
   })
-  if (!res.ok) throw new Error(await res.text())
-  if (onToken && res.body) return readSseStream(res.body, onToken)
-  const data = (await res.json()) as { choices?: { message?: { content?: string | null } }[] }
-  return data.choices?.[0]?.message?.content ?? ''
+  let text = ''
+  for await (const part of result.stream) {
+    if (part.type === 'text-delta') {
+      text += part.text
+      handlers?.onToken?.(part.text)
+    } else if (part.type === 'reasoning-delta') {
+      handlers?.onReasoning?.(part.text)
+    } else if (part.type === 'error') {
+      throw part.error
+    }
+  }
+  return text
 }


### PR DESCRIPTION
## Summary

Batch of fixes and improvements: Inspector multiline fields resize correctly when the panel width changes; the desktop Edit menu no longer hijacks clipboard/undo for the graph; Socrates completions migrate to the Vercel AI SDK with reasoning extraction for thinking models; feedback link moves from the status bar into the About dialog.

## Changes

- **Inspector:** `ResizeObserver` on multiline `InlineEdit` fields; `minWidth: 0` so grid columns can shrink.
- **Desktop:** Tauri predefined Edit menu items for native text editing; remove graph-routing menu handlers; add `isTextControlFocused` shared by `App` and `ReviewMode`.
- **Mentor:** Replace hand-rolled SSE fetch with AI SDK `streamText`; `extractReasoningMiddleware` splits thinking from answer; "thinking…" label while reasoning streams; updated mentor rules and completion tests.
- **UI:** Move Send feedback link from status bar to About dialog; relocate i18n strings from `statusBar` to `about.links`.

## Checklist

- [x] Branch name follows the naming convention
- [ ] `## [Unreleased]` in `CHANGELOG.md` updated

## Testing

- `pnpm test` — completion and shortcuts tests pass.
- Manual: resize Inspector panel with multiline fields; desktop copy/paste in text inputs vs graph shortcuts; mentor streaming with reasoning models; feedback link in About dialog.