### PR TITLE
chore(github): dedupe labels, align issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Propose a new feature or improvement
-labels: [enhancement]
+labels: [feature]
 body:
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/graph_model.yml
+++ b/.github/ISSUE_TEMPLATE/graph_model.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Before proposing, please skim the [Relation types reference](https://nesso.how/docs/reference/relation-types/) and the [`RelationTypeDef` schema](https://github.com/nesso-how/nesso/blob/main/packages/vocab-learning/src/index.ts). Every type must declare both visual encoding **and** semantic coefficients — these drive graph-analysis algorithms, so they need to be studied at the type level.
+        Before proposing, please skim the [Relation types reference](https://nesso.how/docs/reference/relation-types/) and the [`RelationTypeDef` schema](https://github.com/nesso-how/nesso/blob/main/packages/vocab-learning/src/relationTypes.ts). Every type must declare both visual encoding **and** semantic coefficients — these drive graph-analysis algorithms, so they need to be studied at the type level.
 
   - type: textarea
     id: motivation
@@ -28,7 +28,6 @@ body:
         - `line` (solid | dashed | dotted | double | wavy) and `glyph` if relevant
 
         **Semantic coefficients**
-        - `symmetric: boolean`
         - `transitive: 'Y' | 'N' | 'weak'` — if `A r B` and `B r C`, does `A r C` follow?
         - `inverse: RelationTypeName` — canonical inverse in the set (self for symmetric). If you propose an asymmetric type, also propose its inverse.
         - `strength: number` (0..1) — per-type semantic weight; intensity, not per-edge confidence. Briefly justify the value.


### PR DESCRIPTION
## Summary

Cleaned up the repo's GitHub label set (duplicates, color collisions, a missing label) and fixed the two issue templates that referenced labels or schema details that no longer matched.

## Changes

- Renamed `enhancement` → `feature`; added a new `performance` label (for `perf:`-scoped work).
- Moved `area: ci` → `ci` out of the `area: *` group and into the type group, since it matches the project's conventional-commit types (`feat`, `fix`, `docs`, `chore`, `ci`, `refactor`) rather than a functional area of the product.
- Recolored labels that shared an identical color across unrelated meanings: `area: docs`, `area: desktop`, `area: ui`.
- Fixed the stale description on `area: packages` (referenced the old `@nesso-how/relation-types` name; now `@nesso-how/vocab-learning`).
- Added the missing `graph-model` label — `graph_model.yml` referenced it but it didn't exist, so issues opened from that template silently got no label.
- `feature_request.yml`: updated `labels: [enhancement]` → `labels: [feature]` to match the rename.
- `graph_model.yml`: removed a `symmetric: boolean` field that doesn't exist on `RelationTypeDef` (symmetry is already expressed via `inverse: 'self'`), and fixed the schema link to point at `packages/vocab-learning/src/relationTypes.ts` (where `RelationTypeDef` and `RELATION_TYPES` actually live) instead of `index.ts` (which only re-exports it).

Note: the label changes (renames, recolors, new labels) were applied directly via `gh label` against the live repo, since GitHub labels aren't version-controlled files. This PR carries only the two issue-template file changes that fall out of those label changes.

## Checklist

- [x] Branch name follows the naming convention
- [ ] `## [Unreleased]` in `CHANGELOG.md` updated

## Testing

- Verified the final label list via `gh label list` — no remaining duplicate names, no remaining color collisions, no stale descriptions.
- Confirmed every `labels: [...]` reference across `.github/ISSUE_TEMPLATE/*.yml` resolves to an existing label.
- Verified `RelationTypeDef` and its fields directly in `packages/vocab-learning/src/relationTypes.ts` against the template's field list.