### PR TITLE
fix(desktop): suppress false file-conflict banner on timestamp-only disk changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+
+### Fixed
+
+- **Desktop:** The external file-conflict banner no longer fires when nothing actually changed on disk. `reconcileDiskWithIdb` previously pushed a record into its persist queue on a timestamp-only bump (e.g. self-healing name/id normalisation, or the app's own save during the disk-before-fingerprint window); it now requires actual content or name divergence. `handleWatchEvent` additionally compares the freshly-synced disk fingerprint against `savedFingerprint` (using `mergeGraphDisplay` for settings parity) and skips spurious notifications entirely.
+
 ## [0.1.0-alpha.39] - 2026-07-02
 
 ### Changed

--- a/src/hooks/useGraphFileWatch.ts
+++ b/src/hooks/useGraphFileWatch.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { useEffect, useRef } from 'react'
+import { mergeGraphDisplay } from '@/types/graph'
 import { useGraphStore } from '@/store'
 import { graphContentFingerprint } from '@/lib/graphPersist'
 import { dbDeleteGraph, dbListGraphs, dbSaveGraph } from '@/store/db'
@@ -129,14 +130,28 @@ export function useGraphFileWatch() {
         const changedFromDisk = new Set(toPersist.map((r) => r.id))
         if (!changedFromDisk.has(fresh.currentGraphId)) return
 
-        const localFp = graphContentFingerprint(fresh.nodes, fresh.edges, fresh.graphDisplay)
         const active = records.find((r) => r.id === fresh.currentGraphId)
         if (!active) return
 
+        // Compare the freshly-synced disk fingerprint against what we last
+        // saved/loaded. If they match, this is a spurious notification —
+        // e.g. a self-healing name/id rewrite that bumped updatedAt without
+        // changing content, or a name-only change. Skip it entirely.
+        const diskFingerprint = graphContentFingerprint(
+          active.nodes,
+          active.edges,
+          mergeGraphDisplay(active.display, fresh.settings),
+        )
+        if (diskFingerprint === fresh.savedFingerprint) return
+
+        // Disk content actually diverges from what we last saved/loaded.
+        // If the user also has unsaved local changes, it's a real conflict.
+        const localFp = graphContentFingerprint(fresh.nodes, fresh.edges, fresh.graphDisplay)
         if (localFp !== fresh.savedFingerprint) {
           fresh.setExternalFileConflict(true)
           return
         }
+        // Local is clean — safe to auto-reload the disk content.
         await fresh.loadGraph(active.id)
       } finally {
         handlingRef.current = false

--- a/src/lib/workspace/sync.test.ts
+++ b/src/lib/workspace/sync.test.ts
@@ -75,14 +75,23 @@ describe('persistWorkspaceSync', () => {
     expect(manifest.entries[gid(1)]).toMatchObject({ file: 'Solo.json', name: 'Solo' })
   })
 
-  it('picks up a disk file that is newer than its IndexedDB copy', async () => {
+  it('picks up a disk file with newer content', async () => {
     await dbSaveGraph(record(gid(1), 'Doc', 1000))
-    writeDiskFile('Doc.json', { id: gid(1), name: 'Doc', updatedAt: 5000 })
+    tauriFsState.writeFile(
+      '/proj/Doc.json',
+      graphDocumentJson({
+        id: gid(1),
+        name: 'Doc',
+        updatedAt: 5000,
+        concepts: [{ id: 'n1', label: 'fresh edit', x: 0, y: 0 }],
+      }),
+    )
 
     await persistWorkspaceSync(SETTINGS, await dbListGraphs())
 
     const [stored] = await dbListGraphs()
     expect(stored.updatedAt).toBe(5000)
+    expect(stored.nodes).toHaveLength(1)
   })
 
   it('drops a tracked graph whose file was deleted outside the app', async () => {
@@ -122,6 +131,19 @@ describe('persistWorkspaceSync', () => {
 
     const [stored] = await dbListGraphs()
     expect(stored.nodes).toHaveLength(1)
+  })
+
+  it('ignores a disk file whose content is unchanged despite a newer timestamp', async () => {
+    await dbSaveGraph(record(gid(1), 'Doc', 1000))
+    // Same empty content, just a bumped timestamp
+    writeDiskFile('Doc.json', { id: gid(1), name: 'Doc', updatedAt: 5000 })
+
+    await persistWorkspaceSync(SETTINGS, await dbListGraphs())
+
+    const [stored] = await dbListGraphs()
+    // Content is unchanged — the record should NOT have been pushed to toPersist,
+    // so IDB keeps the original updatedAt (1000).
+    expect(stored.updatedAt).toBe(1000)
   })
 })
 

--- a/src/lib/workspace/sync.ts
+++ b/src/lib/workspace/sync.ts
@@ -87,12 +87,14 @@ export async function reconcileDiskWithIdb(
     const idb = idbById.get(id)
     if (
       !idb ||
-      diskRecord.updatedAt > idb.updatedAt ||
       idb.name !== diskRecord.name ||
-      // Equal timestamp but different content: the file was edited externally
-      // without bumping its embedded `updatedAt` (e.g. hand-edited in a text
-      // editor). The folder is the source of truth — pick the change up here,
-      // or the next in-app save would silently overwrite it.
+      // Content differs: the file was edited externally either with a bumped
+      // timestamp or without (e.g. hand-edited in a text editor). The folder
+      // is the source of truth — pick the change up here, or the next in-app
+      // save would silently overwrite it. A newer timestamp with identical
+      // content (self-healing name/id rewrite, or the app's own save before
+      // savedFingerprint updates) is NOT enough — it would cause false
+      // conflict detections in handleWatchEvent.
       !graphPersistEquals(
         {
           nodes: diskRecord.nodes,


### PR DESCRIPTION
## Summary

On desktop, the external file-conflict banner (`GraphFileConflictBanner`) could appear even when nothing actually changed on disk, forcing the user into a reload/keep-local decision for a conflict that didn't exist. Two root causes:

1. `reconcileDiskWithIdb` flagged records into its persist queue on a **timestamp-only bump** — self-healing name/id normalisation rewrites `updatedAt` without changing content, and `saveCurrentGraph` writes to disk before updating `savedFingerprint`, creating a window where the app's own save looks like an external change.
2. `handleWatchEvent` compared only **local-vs-`savedFingerprint`** without diffing disk-vs-`savedFingerprint`, so a name-only or timestamp-only change that ended up in `toPersist` still flagged a conflict when the user had any pending local edits.

## Changes

- `src/lib/workspace/sync.ts` — `reconcileDiskWithIdb` no longer ORs `diskRecord.updatedAt > idb.updatedAt` with the content/name check; **actual content or name divergence** is now required to push into `toPersist`. Comment updated to explain why a newer timestamp with identical content is no longer enough.
- `src/hooks/useGraphFileWatch.ts` — `handleWatchEvent` now computes a **disk fingerprint** from the freshly-synced record (via `mergeGraphDisplay(active.display, fresh.settings)` for settings parity with `savedFingerprint`) and early-returns on match, so spurious notifications (self-healing rewrites, name-only changes) are skipped entirely. A conflict is only flagged when disk content genuinely diverges **and** the user has unsaved local edits; otherwise the disk content is auto-reloaded.
- `src/lib/workspace/sync.test.ts` — replaced the "picks up a disk file that is newer" test with "picks up a disk file with newer content" (uses an actual concept-node change); added a regression test "ignores a disk file whose content is unchanged despite a newer timestamp" (asserts IDB keeps the original `updatedAt`).
- `CHANGELOG.md` — `[Unreleased] › Fixed` entry.

## Checklist

- [x] Branch name follows the naming convention
- [x] `## [Unreleased]` in `CHANGELOG.md` updated

## Testing

- **TDD:** the new "ignores … unchanged despite a newer timestamp" test failed against the old implementation (`expected 1000 to be 5000`) → fix applied → green. 13/13 sync tests pass.
- **Preflight (full CI parity):** format:check ✅, lint ✅ (warnings pre-existing), test:coverage ✅ (351 tests), type:check ✅, build:mcp ✅, build ✅, license-headers ✅, type:coverage ✅ (99.68%), analyze:dead-code ✅, analyze:dupes ✅, analyze:health ✅, Playwright e2e ✅ (11/11).
- **Review:** guard-review + quality-review both returned `Ready to PR` with no blocking findings. One SUGGESTION-tier edge case (display-settings parity via `mergeGraphDisplay` instead of `defaultGraphDisplay()`) was applied and confirmed by a follow-up quality-review.

Closes #94