### PR TITLE
chore(harness): upgrade agent models to GPT-5.6 family and document dev workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ e2e-native/artifacts
 
 # Code-quality tooling (fallow local cache + baselines)
 .fallow/
+
+# Git worktrees — separate working directories, not part of the main repo
+.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Added
+
+- **README:** New "Development workflow" section documenting the OpenCode harness, agent pipeline, and continuous flow model.
+- **Worktree support:** `.worktrees/` added to `.gitignore` so worktree working directories are not accidentally tracked.
+
+### Changed
+
+- **Agent models:** Upgraded Nesso's agent model configuration (`opencode.json`) to GPT-5.6 family (Luna for planning/reviews/brainstorming, Sol for forensic debugging) and DeepSeek v4 Pro for orchestration and implementation, matching capability to cost per phase.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ The AI mentor talks to any OpenAI-compatible `chat/completions` endpoint. On eve
 
 The repo is a pnpm workspace monorepo. The graph vocabulary lives in [packages/vocab-learning](packages/vocab-learning) and is consumed by both the app and an MCP server in [packages/mcp](packages/mcp) that lets LLM clients query relation types, read the bundled docs, build valid graph documents, and validate graph JSON.
 
+## Development workflow
+
+Nesso uses [OpenCode](https://opencode.ai) as its development environment, a modular, multi-provider AI coding tool that aligns with Nesso's own philosophy. We chose it over vendor-locked alternatives because it runs locally against any provider (currently OpenAI, open-weight models via a Go subscription, or local models), supporting a structured workflow built around typed agents, skills, and subagent pipelines:
+
+**The pipeline** (from issue to PR) routes through specialized agents: `fix` forensic traces bugs, `brainstorm` explores design, `plan` produces bite-sized TDD tasks, `build` executes RED-GREEN-REFACTOR per task, `guard-review` checks semantic constraints, and `quality-review` catches bugs and regressions. An orchestrator agent (`work`) dispatches each phase and gates on user approval.
+
+This lets us match model capability to cost per phase without locking into a single model or provider.
+
+The harness lives in `.opencode/` and `.rules/`: agent definitions, skill workflows, and area-specific rules (graph model, store conventions, theme tokens). All tracked in the repo so every contributor sees the same guardrails.
+
+The project is managed with a [kanban board](https://github.com/orgs/nesso-how/projects/1/views/2) tracking active issues and a [roadmap](https://github.com/orgs/nesso-how/projects/1/views/3) for longer-term direction. We follow a continuous flow model rather than sprints or classic agile iterations: work is pulled from the backlog as capacity allows, sized so each unit maps to one agentic pipeline run. This cadence matches the tooling: agents work best on focused, sequential tasks, not time-boxed batches of unrelated work.
+
 ## Packages
 
 Nesso is built as a monorepo of focused packages so that its graph vocabulary, visual components, and tooling can be used independently of the full app. The MCP server, embeddable graph component, and schema layer are all separate entry points into the same underlying model.

--- a/opencode.json
+++ b/opencode.json
@@ -16,27 +16,32 @@
   },
   "agent": {
     "brainstorm": {
-      "model": "opencode-go/glm-5.2"
+      "model": "openai/gpt-5.6-luna",
+      "reasoningEffort": "max"
     },
     "fix": {
-      "model": "opencode-go/glm-5.2"
+      "model": "openai/gpt-5.6-sol",
+      "reasoningEffort": "high"
     },
     "guard-review": {
-      "model": "opencode-go/deepseek-v4-pro"
+      "model": "openai/gpt-5.6-luna",
+      "reasoningEffort": "xhigh"
     },
     "quality-review": {
-      "model": "opencode-go/deepseek-v4-pro"
+      "model": "openai/gpt-5.6-luna",
+      "reasoningEffort": "xhigh"
     },
     "work": {
       "model": "opencode-go/deepseek-v4-pro",
       "variant": "max"
     },
     "plan": {
-      "model": "opencode-go/deepseek-v4-pro",
-      "variant": "max"
+      "model": "openai/gpt-5.6-luna",
+      "reasoningEffort": "max"
     },
     "build": {
-      "model": "opencode-go/deepseek-v4-flash"
+      "model": "opencode-go/deepseek-v4-pro",
+      "variant": "high"
     },
     "harness": {
       "model": "opencode/big-pickle"


### PR DESCRIPTION
## Summary

Update Nesso's agent model configuration to the GPT-5.6 family (Sol/Terra/Luna) with a mix of OpenAI and open-weight models via Go subscription, and document the development workflow in the README.

## Changes

- **Agent models:** GPT-5.6 Luna with varying reasoning effort for planning, reviews, and brainstorming; GPT-5.6 Sol for forensic debugging; DeepSeek v4 Pro for orchestration and implementation. Drops GLM 5.2 and DeepSeek v4 Flash.
- **README:** New "Development workflow" section covering the OpenCode harness, agent pipeline, `.opencode/` and `.rules/` conventions, kanban board, roadmap, and continuous flow model.
- **.gitignore:** Added `.worktrees/` to prevent accidental tracking of git worktree directories.
- **CHANGELOG.md:** Updated `[Unreleased]` with the above changes.

## Checklist

- [x] Branch name follows the naming convention
- [x] `## [Unreleased]` in `CHANGELOG.md` updated

## Testing

- `pnpm run fast-check` passes (format, lint, types, tests)