### PR TITLE
fix(canvas): prevent silent relation-direction reversal on drag-connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 - **Desktop:** The external file-conflict banner no longer fires when nothing actually changed on disk. `reconcileDiskWithIdb` previously pushed a record into its persist queue on a timestamp-only bump (e.g. self-healing name/id normalisation, or the app's own save during the disk-before-fingerprint window); it now requires actual content or name divergence. `handleWatchEvent` additionally compares the freshly-synced disk fingerprint against `savedFingerprint` (using `mergeGraphDisplay` for settings parity) and skips spurious notifications entirely.
 
+- **Canvas:** Dragging a connection from a node's left-side (target) handles no longer silently reverses the relation's source/target direction. Target handles now have `isConnectableStart={false}`, preventing a connection drag from starting there.
+
 ## [0.1.0-alpha.39] - 2026-07-02
 
 ### Changed

--- a/src/components/canvas/ConceptNode.tsx
+++ b/src/components/canvas/ConceptNode.tsx
@@ -244,6 +244,7 @@ export function ConceptNode({ id, data, selected }: NodeProps<ConceptNodeType>) 
         id={CONCEPT_HANDLE_IN}
         type="target"
         position={Position.Left}
+        isConnectableStart={false}
         className="nesso-node-handle"
         style={{
           width: 22,
@@ -258,6 +259,7 @@ export function ConceptNode({ id, data, selected }: NodeProps<ConceptNodeType>) 
         id="in-c1"
         type="target"
         position={Position.Left}
+        isConnectableStart={false}
         style={{
           left: '33%',
           top: '50%',
@@ -274,6 +276,7 @@ export function ConceptNode({ id, data, selected }: NodeProps<ConceptNodeType>) 
         id="in-c2"
         type="target"
         position={Position.Left}
+        isConnectableStart={false}
         style={{
           left: '67%',
           top: '50%',


### PR DESCRIPTION
## Summary

Fixes a bug where dragging a connection from a concept node's left-side (target) handles could silently swap the stored source/target node IDs. The edge rendered looking normal either way because `addEdge` always sets `sourceHandle: out` / `targetHandle: in` regardless of actual direction — so the semantic flip was invisible.

## Changes

- **`src/components/canvas/ConceptNode.tsx`**: Added `isConnectableStart={false}` to all three target `<Handle>` elements (`in`, `in-c1`, `in-c2`). This prevents React Flow from starting a connection drag from target-type handles under `ConnectionMode.Loose`, which was the root cause of the silent swap in `@xyflow/system`'s `isValidHandle`.

Closes #95

## Checklist

- [x] Branch name follows the naming convention
- [x] `## [Unreleased]` in `CHANGELOG.md` updated

## Testing

- `pnpm run fast-check` — all 4 steps pass (format, lint, type-check, test)
- `pnpm run preflight` — all 11/11 steps pass
- `pnpm test:e2e` — all 11 e2e specs pass, including drag-connect tests
- Manual: dragging from the left side of a concept node produces no connection line; dragging from the right-side source handle works normally with correct direction