### PR TITLE
refactor(graph): drop line style from edge visual encoding

### DIFF
--- a/.rules/graph-model.md
+++ b/.rules/graph-model.md
@@ -89,7 +89,6 @@ Each definition has:
 
 - `cat: RelationCategory` — which category it belongs to
 - `label: string` — human-readable label
-- `line: 'solid' | 'dashed' | 'dotted' | 'double' | 'wavy'` — stroke style
 - `glyph: GlyphKind` — SVG icon at the target end
 - `transitive: 'Y' | 'N' | 'weak'` — `weak` = transitivity with decay; algorithms may discount per step
 - `inverse: RelationTypeName | 'self'` — canonical inverse in the set; `'self'` for symmetric types (`contrasts-with`, `opposite-of`, `similar-to`, `analogous-to`, `contradicts`, `overlaps-with`)
@@ -103,9 +102,9 @@ These properties exist to drive future graph-analysis and graph-comparison algor
 
 `NessoEdge` renders each edge according to its `RelationTypeDef`. The amount of visual information shown depends on the `edgeEncoding` setting:
 
-- `full` — category colour + per-type line style + glyph + arrowhead + always-on label
-- `category` — same as `full` (colour, line style, glyph, arrowhead) but the label shows only on hover/selection
-- `minimal` — plain solid line in a neutral grey: no glyph, arrowhead, label, or category colour
+- `full` — category colour + glyph + arrowhead + always-on label
+- `category` — category colour + glyph + arrowhead; label only on hover/selection
+- `minimal` — plain solid neutral line — no glyph, arrowhead, label, or category colour
 
 Category colours are CSS custom properties (`--cat-taxonomic`, `--cat-structural`, etc.) set by the active palette in `App.tsx` from `PALETTES` in `@nesso-how/vocab-learning`. Embeds use hex from `PALETTES` directly via `categoryColorMode: 'palette'`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Update the canonical `.rules/*.md` in the same change when your edit makes a rul
 
 - `components.md` — `src/components/**/*.tsx`
 - `store.md` — `src/store/**/*.ts`
-- `graph-model.md` — `src/data/relationTypes.ts`, `src/types/graph.ts`, `packages/graph/src/NessoEdge.tsx`, `src/components/dialogs/RelationTypesDialog.tsx`, `packages/vocab-learning/src/index.ts`
+- `graph-model.md` — `src/data/relationTypes.ts`, `src/types/graph.ts`, `packages/graph/src/NessoEdge.tsx`, `src/components/dialogs/RelationTypesDialog.tsx`, `packages/vocab-learning/src/index.ts`, `packages/vocab-learning/src/relationTypes.ts`
 - `mentor.md` — `src/components/mentor/MentorPanel.tsx`, `src/llm/completion.ts`, `src/llm/context.ts`
 - `conventions.md` — `src/**/*.{ts,tsx}` (only when conventions change, not every src edit)
 - `testing.md` — `**/*.test.{ts,tsx}`; also `vitest.config.ts`, `playwright.config.ts`, `e2e/**`, CI test steps
@@ -61,7 +61,7 @@ Update the canonical `.rules/*.md` in the same change when your edit makes a rul
 
 ### Never use default React Flow edge types
 
-All edges must use `type: 'nesso'`. The `NessoEdge` renderer from `@nesso-how/graph` is load-bearing for visual encoding (line style, glyph, category colour). Plain React Flow edges skip all of this.
+All edges must use `type: 'nesso'`. The `NessoEdge` renderer from `@nesso-how/graph` is load-bearing for visual encoding (glyph, category colour). Plain React Flow edges skip all of this.
 
 ### Never hardcode edge colours
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - **Agent models:** Upgraded Nesso's agent model configuration (`opencode.json`) to GPT-5.6 family (Luna for planning/reviews/brainstorming, Sol for forensic debugging) and DeepSeek v4 Pro for orchestration and implementation, matching capability to cost per phase.
 - **Work agent:** PRs created through the orchestration flow now have GitHub auto-merge enabled by default (`gh pr merge --auto --squash`), so they merge automatically once all required checks pass.
 
+- **Edge encoding:** Dropped the per-type line style channel from `RelationTypeDef` (52 relation types). Edges now render with solid strokes in all encoding modes, using category colour + glyph as the two remaining visual channels. Touched `NessoEdge`, `RelationTypesDialog`, MCP payload, rules, and docs.
+
 ### Fixed
 
 - **Desktop:** The external file-conflict banner no longer fires when nothing actually changed on disk. `reconcileDiskWithIdb` previously pushed a record into its persist queue on a timestamp-only bump (e.g. self-healing name/id normalisation, or the app's own save during the disk-before-fingerprint window); it now requires actual content or name divergence. `handleWatchEvent` additionally compares the freshly-synced disk fingerprint against `savedFingerprint` (using `mergeGraphDisplay` for settings parity) and skips spurious notifications entirely.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ docs/             Starlight docs site, published at nesso.how/docs
 
 Nesso is a React 18 + Vite + TypeScript single-page app, optionally wrapped by Tauri v2 for a native desktop shell. All state lives in a single [Zustand](https://github.com/pmndrs/zustand) store, with components subscribing via selectors and no prop drilling.
 
-The canvas is built on [React Flow](https://reactflow.dev/) with a custom edge renderer that encodes each relation type as a distinct line style and SVG glyph. Graph content persists to IndexedDB on web and is also written to a folder of `.json` files on desktop, with a file watcher that picks up external edits. FSRS review progress lives in a separate IndexedDB store and is never mixed into the shared graph files.
+The canvas is built on [React Flow](https://reactflow.dev/) with a custom edge renderer that encodes each relation type as a category colour and SVG glyph. Graph content persists to IndexedDB on web and is also written to a folder of `.json` files on desktop, with a file watcher that picks up external edits. FSRS review progress lives in a separate IndexedDB store and is never mixed into the shared graph files.
 
 The AI mentor talks to any OpenAI-compatible `chat/completions` endpoint. On every send the system prompt is rebuilt from the live store, so the model always sees the current graph, the active selection, and a focal neighbourhood of related concepts.
 

--- a/docs/src/content/docs/docs/guides/building-a-graph.md
+++ b/docs/src/content/docs/docs/guides/building-a-graph.md
@@ -22,7 +22,7 @@ Drag from a node's right edge (`out` handle) to another node's left edge (`in` h
 - The connection line previews with the same quadratic geometry the final edge uses.
 - Edge type can be changed any time from the Inspector when an edge is selected.
 
-See the [relation types reference](../../reference/relation-types/) for the full list, semantic meaning, and type properties. Per-type line style and glyph come from `@nesso-how/vocab-learning`. Edge encoding density is under [Display options](#display-options-sidebar) below.
+See the [relation types reference](../../reference/relation-types/) for the full list, semantic meaning, and type properties. Each type has a category colour and an SVG glyph, both defined in `@nesso-how/vocab-learning`. Edge encoding density is under [Display options](#display-options-sidebar) below.
 
 ## Selecting and editing
 

--- a/docs/src/content/docs/docs/reference/mcp-tools.md
+++ b/docs/src/content/docs/docs/reference/mcp-tools.md
@@ -11,7 +11,7 @@ Fetches documentation pages from this site. Call it without a `slug` to get a ta
 
 ### `get_relation_types`
 
-Returns the complete list of relation types grouped by category id (`taxonomic`, `structural`, and so on from `RELATION_CATEGORIES` in `@nesso-how/vocab-learning`), with line style, symmetry, and type properties (transitive, inverse, strength, polarity, cardinality). Use this whenever you need valid type names for graph JSON or explanations for the learner.
+Returns the complete list of relation types grouped by category id (`taxonomic`, `structural`, and so on from `RELATION_CATEGORIES` in `@nesso-how/vocab-learning`), with glyph, symmetry, and type properties (transitive, inverse, strength, polarity, cardinality). Use this whenever you need valid type names for graph JSON or explanations for the learner.
 
 ### `validate_graph`
 

--- a/docs/src/content/docs/docs/reference/relation-types.md
+++ b/docs/src/content/docs/docs/reference/relation-types.md
@@ -19,6 +19,10 @@ Each relation type declares the properties below. They define the contract that 
 - **Polarity (P)**: `+1` positive effect, `-1` antagonistic, `0` neutral/structural. From signed-network theory <a id="cite-4" href="#ref-4">[4]</a>: with polarity, the graph becomes a signed network where balance and cycle-sign analyses can apply.
 - **Cardinality (C)**: expected mapping pattern, always declared. One of `1-1`, `1-N`, `N-1`, `N-N` (no a-priori constraint). Setting this consistently lets algorithms flag structural anomalies (e.g. two competing `defines` edges into the same term).
 
+## Visual encoding
+
+- **Visual encoding**: category colour gives a coarse signal across the 8 categories; each type also has a glyph for a finer, near-type-level signal. Edge strokes are solid in every encoding mode.
+
 ## Categories
 
 Each category answers a specific question about the relation. Grouping the types by question makes the vocabulary easier to navigate when authoring a graph, and lets graph-analysis algorithms compare and aggregate at category level instead of only per individual type.

--- a/e2e/edge-encoding.spec.ts
+++ b/e2e/edge-encoding.spec.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+import { test, expect } from '@playwright/test'
+import { connectAlphaBeta, edges, gotoApp, newEmptyGraph, seedTwoConcepts } from './helpers'
+
+test.beforeEach(async ({ page }) => {
+  await gotoApp(page)
+  await newEmptyGraph(page)
+})
+
+test('uses solid paths while preserving glyph visibility in non-minimal modes', async ({
+  page,
+}) => {
+  await seedTwoConcepts(page)
+  await connectAlphaBeta(page, 'similar-to')
+
+  const edge = edges(page).first()
+
+  for (const encoding of ['Full', 'Cat.']) {
+    await page.getByRole('button', { name: encoding, exact: true }).click()
+
+    await expect(edge.locator('path[stroke-dasharray]')).toHaveCount(0)
+    await expect(edge.locator('circle')).toHaveCount(1)
+    await expect(edge.locator('path').nth(1)).toHaveAttribute('stroke', 'var(--cat-similarity)')
+  }
+
+  await page.getByRole('button', { name: 'Min.', exact: true }).click()
+
+  await expect(edge.locator('path[stroke-dasharray]')).toHaveCount(0)
+  await expect(edge.locator('circle')).toHaveCount(0)
+})
+
+test('relation types dialog previews solid strokes and glyphs', async ({ page }) => {
+  await page.getByTestId('graph-io-menu').click()
+
+  const menu = page.getByRole('menu')
+  await menu.getByRole('button', { name: 'Relation types', exact: true }).click()
+
+  const dialog = page.getByRole('dialog')
+  await expect(dialog).toBeVisible()
+  await expect(dialog.locator('svg path[stroke-dasharray]')).toHaveCount(0)
+  await expect(dialog.locator('svg[width="36"] > circle')).toHaveCount(52)
+})

--- a/packages/graph/src/NessoEdge.tsx
+++ b/packages/graph/src/NessoEdge.tsx
@@ -34,57 +34,6 @@ function categoryColor(
   return PALETTES[palette]?.[cat] ?? '#666666'
 }
 
-function EdgePathElement({
-  d,
-  color,
-  lineStyle,
-  width = 1.5,
-  opacity = 0.78,
-}: {
-  d: string
-  color: string
-  lineStyle: string
-  width?: number
-  opacity?: number
-}) {
-  const base = {
-    fill: 'none',
-    stroke: color,
-    strokeWidth: width,
-    opacity,
-    strokeLinecap: 'round' as const,
-  }
-
-  if (lineStyle === 'double') {
-    return (
-      <g>
-        <path
-          d={d}
-          fill="none"
-          stroke="var(--paper, #ffffff)"
-          strokeWidth={width + 3}
-          opacity={1}
-        />
-        <path d={d} {...base} strokeWidth={width * 2.6} />
-        <path
-          d={d}
-          fill="none"
-          stroke="var(--paper, #ffffff)"
-          strokeWidth={width * 0.7}
-          opacity={1}
-        />
-      </g>
-    )
-  }
-  if (lineStyle === 'wavy') {
-    return <path d={d} {...base} strokeDasharray="1 4" strokeWidth={width * 1.2} />
-  }
-  if (lineStyle === 'dashed') return <path d={d} {...base} strokeDasharray="6 5" />
-  if (lineStyle === 'dotted')
-    return <path d={d} {...base} strokeDasharray="0.1 5" strokeWidth={width * 1.4} />
-  return <path d={d} {...base} />
-}
-
 type NessoFlowEdge = Edge<NessoEdgeData, 'nesso'>
 
 export function NessoEdge({ id, source, target, data, selected }: EdgeProps<NessoFlowEdge>) {
@@ -108,7 +57,6 @@ export function NessoEdge({ id, source, target, data, selected }: EdgeProps<Ness
     edgeEncoding === 'minimal'
       ? 'var(--ink-3, #888888)'
       : categoryColor(T.cat, categoryColorMode, palette)
-  const lineStyle = edgeEncoding === 'minimal' ? 'solid' : T.line
   const isSelected = selected || isItemSelected?.('edge', id) === true
   const showLabel =
     edgeEncoding === 'full' || (edgeEncoding !== 'minimal' && (hovered || isSelected))
@@ -182,7 +130,14 @@ export function NessoEdge({ id, source, target, data, selected }: EdgeProps<Ness
     >
       <path d={path} stroke="transparent" strokeWidth={14} fill="none" />
 
-      <EdgePathElement d={path} color={color} lineStyle={lineStyle} width={w} opacity={op} />
+      <path
+        d={path}
+        fill="none"
+        stroke={color}
+        strokeWidth={w}
+        opacity={op}
+        strokeLinecap="round"
+      />
 
       {T.inverse !== 'self' && edgeEncoding !== 'minimal' && (
         <polygon points={`${b.x},${b.y} ${ax1},${ay1} ${ax2},${ay2}`} fill={color} opacity={0.85} />

--- a/packages/mcp/src/tools/get-relation-types.test.ts
+++ b/packages/mcp/src/tools/get-relation-types.test.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+import { describe, expect, it } from 'vitest'
+import { RELATION_CATEGORIES, RELATION_TYPES } from '@nesso-how/vocab-learning'
+import { getRelationTypesPayload } from './get-relation-types.js'
+
+describe('getRelationTypesPayload', () => {
+  it('returns glyphs without line styles for every relation type', () => {
+    const payload = getRelationTypesPayload()
+    const types = payload.flatMap((category) => category.types)
+
+    expect(payload.map((category) => category.category)).toEqual([...RELATION_CATEGORIES])
+    expect(types).toHaveLength(52)
+
+    for (const type of types) {
+      expect(type.glyph).toBe(RELATION_TYPES[type.type].glyph)
+      expect(type).not.toHaveProperty('line')
+    }
+  })
+})

--- a/packages/mcp/src/tools/get-relation-types.ts
+++ b/packages/mcp/src/tools/get-relation-types.ts
@@ -1,7 +1,52 @@
 // SPDX-License-Identifier: MIT
 import type { McpServer } from '@modelcontextprotocol/server'
 import * as z from 'zod/v4'
-import { RELATION_TYPES, RELATION_CATEGORIES } from '@nesso-how/vocab-learning'
+import {
+  RELATION_TYPES,
+  RELATION_CATEGORIES,
+  type GlyphKind,
+  type RelationCategory,
+  type RelationTypeName,
+  type Transitivity,
+  type Polarity,
+  type Cardinality,
+} from '@nesso-how/vocab-learning'
+
+export type RelationTypePayload = {
+  type: RelationTypeName
+  label: string
+  glyph: GlyphKind
+  symmetric: boolean
+  transitive: Transitivity
+  inverse: RelationTypeName | 'self'
+  strength: number
+  polarity: Polarity
+  cardinality: Cardinality
+}
+
+export type RelationTypesPayload = Array<{
+  category: RelationCategory
+  types: RelationTypePayload[]
+}>
+
+export function getRelationTypesPayload(): RelationTypesPayload {
+  return RELATION_CATEGORIES.map((cat) => ({
+    category: cat,
+    types: Object.entries(RELATION_TYPES)
+      .filter(([, def]) => def.cat === cat)
+      .map(([name, def]) => ({
+        type: name as RelationTypeName,
+        label: def.label,
+        glyph: def.glyph,
+        symmetric: def.inverse === 'self',
+        transitive: def.transitive,
+        inverse: def.inverse,
+        strength: def.strength,
+        polarity: def.polarity,
+        cardinality: def.cardinality,
+      })),
+  }))
+}
 
 export function registerGetRelationTypes(server: McpServer): void {
   server.registerTool(
@@ -10,27 +55,12 @@ export function registerGetRelationTypes(server: McpServer): void {
       description:
         'Returns all 52 semantic relation types supported by Nesso, grouped by 8 categories. ' +
         'Each type carries type properties (transitive, inverse, strength, polarity, cardinality) ' +
-        'in addition to its visual encoding. ' +
+        'in addition to its glyph. ' +
         'Use this when you need valid relation type names for graph JSON or explanations for the user.',
       inputSchema: z.object({}),
     },
     async () => {
-      const result = RELATION_CATEGORIES.map((cat) => ({
-        category: cat,
-        types: Object.entries(RELATION_TYPES)
-          .filter(([, def]) => def.cat === cat)
-          .map(([name, def]) => ({
-            type: name,
-            label: def.label,
-            line: def.line,
-            symmetric: def.inverse === 'self',
-            transitive: def.transitive,
-            inverse: def.inverse,
-            strength: def.strength,
-            polarity: def.polarity,
-            cardinality: def.cardinality,
-          })),
-      }))
+      const result = getRelationTypesPayload()
 
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -9,5 +9,6 @@
     "declaration": true,
     "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/packages/vocab-learning/src/relationTypes.test.ts
+++ b/packages/vocab-learning/src/relationTypes.test.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+import { describe, expect, it } from 'vitest'
+import { RELATION_TYPES } from './relationTypes.js'
+
+describe('RELATION_TYPES visual encoding', () => {
+  it('uses glyphs without a per-type line style', () => {
+    expect(Object.keys(RELATION_TYPES)).toHaveLength(52)
+
+    for (const definition of Object.values(RELATION_TYPES)) {
+      expect(definition.glyph).toBeDefined()
+      expect(definition).not.toHaveProperty('line')
+    }
+  })
+})

--- a/packages/vocab-learning/src/relationTypes.ts
+++ b/packages/vocab-learning/src/relationTypes.ts
@@ -2,7 +2,7 @@
 //
 // Semantic relation vocabulary: ordered categories, 52 typed relation ids, and
 // per-type properties (transitive, inverse, strength, polarity, cardinality)
-// plus visual encoding hints (line, glyph). UI labels live in app i18n, not here.
+// plus visual encoding (category colour + glyph). UI labels live in app i18n, not here.
 
 export const RELATION_CATEGORIES = [
   'taxonomic',
@@ -124,7 +124,6 @@ export interface RelationTypeDef {
   cat: RelationCategory
   label: string
   // visual encoding
-  line: 'solid' | 'dashed' | 'dotted' | 'double' | 'wavy'
   glyph: GlyphKind
   // type properties
   transitive: Transitivity
@@ -141,7 +140,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'subtype-of': {
     cat: 'taxonomic',
     label: 'subtype of',
-    line: 'double',
     glyph: 'triangle-up',
     transitive: 'Y',
     inverse: 'has-subtype',
@@ -152,7 +150,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'has-subtype': {
     cat: 'taxonomic',
     label: 'has subtype',
-    line: 'double',
     glyph: 'triangle-up',
     transitive: 'Y',
     inverse: 'subtype-of',
@@ -163,7 +160,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'instance-of': {
     cat: 'taxonomic',
     label: 'instance of',
-    line: 'solid',
     glyph: 'circle-dot',
     transitive: 'N',
     inverse: 'has-instance',
@@ -174,7 +170,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'has-instance': {
     cat: 'taxonomic',
     label: 'has instance',
-    line: 'solid',
     glyph: 'circle-dot',
     transitive: 'N',
     inverse: 'instance-of',
@@ -187,7 +182,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'part-of': {
     cat: 'structural',
     label: 'part of',
-    line: 'solid',
     glyph: 'diamond',
     transitive: 'Y',
     inverse: 'contains',
@@ -198,7 +192,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   contains: {
     cat: 'structural',
     label: 'contains',
-    line: 'solid',
     glyph: 'diamond-open',
     transitive: 'Y',
     inverse: 'part-of',
@@ -209,7 +202,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'made-of': {
     cat: 'structural',
     label: 'made of',
-    line: 'dashed',
     glyph: 'hash',
     transitive: 'weak',
     inverse: 'composes',
@@ -220,7 +212,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   composes: {
     cat: 'structural',
     label: 'composes',
-    line: 'dashed',
     glyph: 'hash',
     transitive: 'weak',
     inverse: 'made-of',
@@ -233,7 +224,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   causes: {
     cat: 'causal',
     label: 'causes',
-    line: 'solid',
     glyph: 'arrow-right',
     transitive: 'N',
     inverse: 'caused-by',
@@ -244,7 +234,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'caused-by': {
     cat: 'causal',
     label: 'caused by',
-    line: 'solid',
     glyph: 'arrow-right',
     transitive: 'N',
     inverse: 'causes',
@@ -255,7 +244,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   produces: {
     cat: 'causal',
     label: 'produces',
-    line: 'solid',
     glyph: 'asterisk',
     transitive: 'N',
     inverse: 'produced-by',
@@ -266,7 +254,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'produced-by': {
     cat: 'causal',
     label: 'produced by',
-    line: 'solid',
     glyph: 'asterisk',
     transitive: 'N',
     inverse: 'produces',
@@ -277,7 +264,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   enables: {
     cat: 'causal',
     label: 'enables',
-    line: 'dotted',
     glyph: 'key',
     transitive: 'weak',
     inverse: 'enabled-by',
@@ -288,7 +274,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'enabled-by': {
     cat: 'causal',
     label: 'enabled by',
-    line: 'dotted',
     glyph: 'key',
     transitive: 'weak',
     inverse: 'enables',
@@ -299,7 +284,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   prevents: {
     cat: 'causal',
     label: 'prevents',
-    line: 'dotted',
     glyph: 'block',
     transitive: 'N',
     inverse: 'prevented-by',
@@ -310,7 +294,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'prevented-by': {
     cat: 'causal',
     label: 'prevented by',
-    line: 'dotted',
     glyph: 'block',
     transitive: 'N',
     inverse: 'prevents',
@@ -321,7 +304,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   triggers: {
     cat: 'causal',
     label: 'triggers',
-    line: 'solid',
     glyph: 'spark',
     transitive: 'N',
     inverse: 'triggered-by',
@@ -332,7 +314,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'triggered-by': {
     cat: 'causal',
     label: 'triggered by',
-    line: 'solid',
     glyph: 'spark',
     transitive: 'N',
     inverse: 'triggers',
@@ -343,7 +324,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   inhibits: {
     cat: 'causal',
     label: 'inhibits',
-    line: 'dotted',
     glyph: 'minus',
     transitive: 'N',
     inverse: 'inhibited-by',
@@ -354,7 +334,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'inhibited-by': {
     cat: 'causal',
     label: 'inhibited by',
-    line: 'dotted',
     glyph: 'minus',
     transitive: 'N',
     inverse: 'inhibits',
@@ -365,7 +344,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   disables: {
     cat: 'causal',
     label: 'disables',
-    line: 'dotted',
     glyph: 'lock',
     transitive: 'weak',
     inverse: 'disabled-by',
@@ -376,7 +354,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'disabled-by': {
     cat: 'causal',
     label: 'disabled by',
-    line: 'dotted',
     glyph: 'lock',
     transitive: 'weak',
     inverse: 'disables',
@@ -387,7 +364,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   consumes: {
     cat: 'causal',
     label: 'consumes',
-    line: 'solid',
     glyph: 'flame',
     transitive: 'N',
     inverse: 'consumed-by',
@@ -398,7 +374,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'consumed-by': {
     cat: 'causal',
     label: 'consumed by',
-    line: 'solid',
     glyph: 'flame',
     transitive: 'N',
     inverse: 'consumes',
@@ -409,7 +384,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   delays: {
     cat: 'causal',
     label: 'delays',
-    line: 'dotted',
     glyph: 'hourglass',
     transitive: 'weak',
     inverse: 'delayed-by',
@@ -420,7 +394,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'delayed-by': {
     cat: 'causal',
     label: 'delayed by',
-    line: 'dotted',
     glyph: 'hourglass',
     transitive: 'weak',
     inverse: 'delays',
@@ -433,7 +406,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   requires: {
     cat: 'dependency',
     label: 'requires',
-    line: 'solid',
     glyph: 'anchor',
     transitive: 'Y',
     inverse: 'required-by',
@@ -444,7 +416,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'required-by': {
     cat: 'dependency',
     label: 'required by',
-    line: 'solid',
     glyph: 'anchor',
     transitive: 'Y',
     inverse: 'requires',
@@ -455,7 +426,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   uses: {
     cat: 'dependency',
     label: 'uses',
-    line: 'dashed',
     glyph: 'tool',
     transitive: 'weak',
     inverse: 'used-by',
@@ -466,7 +436,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'used-by': {
     cat: 'dependency',
     label: 'used by',
-    line: 'dashed',
     glyph: 'tool',
     transitive: 'weak',
     inverse: 'uses',
@@ -477,7 +446,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'used-for': {
     cat: 'dependency',
     label: 'used for',
-    line: 'dashed',
     glyph: 'flag',
     transitive: 'N',
     inverse: 'purpose-of',
@@ -488,7 +456,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'purpose-of': {
     cat: 'dependency',
     label: 'purpose of',
-    line: 'dashed',
     glyph: 'flag',
     transitive: 'N',
     inverse: 'used-for',
@@ -501,7 +468,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   precedes: {
     cat: 'temporal',
     label: 'precedes',
-    line: 'solid',
     glyph: 'chevron-r',
     transitive: 'Y',
     inverse: 'follows',
@@ -512,7 +478,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   follows: {
     cat: 'temporal',
     label: 'follows',
-    line: 'solid',
     glyph: 'chevron-r',
     transitive: 'Y',
     inverse: 'precedes',
@@ -523,7 +488,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'occurs-in': {
     cat: 'temporal',
     label: 'occurs in',
-    line: 'dotted',
     glyph: 'ring',
     transitive: 'Y',
     inverse: 'has-occurrence',
@@ -534,7 +498,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'has-occurrence': {
     cat: 'temporal',
     label: 'has occurrence',
-    line: 'dotted',
     glyph: 'ring',
     transitive: 'Y',
     inverse: 'occurs-in',
@@ -545,7 +508,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   during: {
     cat: 'temporal',
     label: 'during',
-    line: 'solid',
     glyph: 'brackets',
     transitive: 'Y',
     inverse: 'spans',
@@ -556,7 +518,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   spans: {
     cat: 'temporal',
     label: 'spans',
-    line: 'solid',
     glyph: 'brackets',
     transitive: 'Y',
     inverse: 'during',
@@ -567,7 +528,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'overlaps-with': {
     cat: 'temporal',
     label: 'overlaps with',
-    line: 'dashed',
     glyph: 'overlap',
     transitive: 'N',
     inverse: 'self',
@@ -578,7 +538,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'derives-from': {
     cat: 'temporal',
     label: 'derives from',
-    line: 'solid',
     glyph: 'branch',
     transitive: 'Y',
     inverse: 'gives-rise-to',
@@ -589,7 +548,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'gives-rise-to': {
     cat: 'temporal',
     label: 'gives rise to',
-    line: 'solid',
     glyph: 'branch',
     transitive: 'Y',
     inverse: 'derives-from',
@@ -602,7 +560,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'contrasts-with': {
     cat: 'opposition',
     label: 'contrasts with',
-    line: 'wavy',
     glyph: 'tilde',
     transitive: 'N',
     inverse: 'self',
@@ -613,7 +570,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'opposite-of': {
     cat: 'opposition',
     label: 'opposite of',
-    line: 'double',
     glyph: 'x',
     transitive: 'N',
     inverse: 'self',
@@ -626,7 +582,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'similar-to': {
     cat: 'similarity',
     label: 'similar to',
-    line: 'dashed',
     glyph: 'approx',
     transitive: 'weak',
     inverse: 'self',
@@ -637,7 +592,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'analogous-to': {
     cat: 'similarity',
     label: 'analogous to',
-    line: 'dotted',
     glyph: 'arrows-lr',
     transitive: 'N',
     inverse: 'self',
@@ -650,7 +604,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   supports: {
     cat: 'epistemic',
     label: 'supports',
-    line: 'dotted',
     glyph: 'check',
     transitive: 'weak',
     inverse: 'supported-by',
@@ -661,7 +614,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'supported-by': {
     cat: 'epistemic',
     label: 'supported by',
-    line: 'dotted',
     glyph: 'check',
     transitive: 'weak',
     inverse: 'supports',
@@ -672,7 +624,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   contradicts: {
     cat: 'epistemic',
     label: 'contradicts',
-    line: 'dotted',
     glyph: 'slash',
     transitive: 'N',
     inverse: 'self',
@@ -683,7 +634,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   explains: {
     cat: 'epistemic',
     label: 'explains',
-    line: 'solid',
     glyph: 'bulb',
     transitive: 'weak',
     inverse: 'explained-by',
@@ -694,7 +644,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'explained-by': {
     cat: 'epistemic',
     label: 'explained by',
-    line: 'solid',
     glyph: 'bulb',
     transitive: 'weak',
     inverse: 'explains',
@@ -705,7 +654,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   defines: {
     cat: 'epistemic',
     label: 'defines',
-    line: 'solid',
     glyph: 'equals',
     transitive: 'N',
     inverse: 'defined-by',
@@ -716,7 +664,6 @@ export const RELATION_TYPES: Record<RelationTypeName, RelationTypeDef> = {
   'defined-by': {
     cat: 'epistemic',
     label: 'defined by',
-    line: 'solid',
     glyph: 'equals',
     transitive: 'N',
     inverse: 'defines',

--- a/packages/vocab-learning/tsconfig.json
+++ b/packages/vocab-learning/tsconfig.json
@@ -9,5 +9,6 @@
     "declaration": true,
     "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/src/components/dialogs/RelationTypesDialog.tsx
+++ b/src/components/dialogs/RelationTypesDialog.tsx
@@ -230,15 +230,6 @@ export function RelationTypesDialog({ open, onClose }: Props) {
                         stroke={encoding === 'minimal' ? 'var(--ink-3)' : g.color}
                         strokeWidth={1.4}
                         strokeLinecap="round"
-                        strokeDasharray={
-                          edgeDef.line === 'dashed'
-                            ? '6 5'
-                            : edgeDef.line === 'dotted'
-                              ? '0.1 5'
-                              : edgeDef.line === 'wavy'
-                                ? '1 4'
-                                : '0'
-                        }
                       />
                       <circle
                         cx="18"


### PR DESCRIPTION
## Summary

Simplify edge visual encoding by dropping the `line` style channel from `RelationTypeDef`. Edges now render with **solid strokes** in all encoding modes, keeping **category colour** (coarse, per-category) and **glyph** (fine, per-type) as the two remaining visual channels.

The `line` property (`solid|dashed|dotted|double|wavy`) carried no learnable semantic meaning — it was ad-hoc visual variety that duplicated the glyph channel, which already varies at near-type granularity and is the higher-signal channel.

## Changes

- **Vocabulary** — Removed `line` from `RelationTypeDef` and all 52 `RELATION_TYPES` definitions. Added unit test asserting no `line` property remains.
- **NessoEdge** — Deleted the `EdgePathElement` private function (49 lines of conditional line-style rendering). Replaced with a plain solid `<path>`. All `edgeEncoding` modes (`full`, `category`, `minimal`) render solid strokes.
- **RelationTypesDialog** — Removed `strokeDasharray` conditional from preview SVG paths.
- **MCP** — Extracted `getRelationTypesPayload()` returning `glyph` instead of `line`. Added unit test.
- **Rules** — Updated `.rules/graph-model.md` visual encoding section and AGENTS constraint to describe glyph + category colour only.
- **Docs** — Updated README, docs site (4 pages), and regenerated MCP documentation bundle.
- **Tests** — New Playwright e2e test (3 test cases) verifying solid paths, glyph visibility, and category colours across encoding modes.

Preflight: 11/11 passed.

## Checklist

- [x] Branch name follows the naming convention
- [x] `## [Unreleased]` in `CHANGELOG.md` updated

## Testing

```bash
pnpm run preflight  # 11/11 passed
pnpm test:e2e e2e/edge-encoding.spec.ts  # 3 tests pass
pnpm test packages/vocab-learning/src/relationTypes.test.ts  # PASS
pnpm test packages/mcp/src/tools/get-relation-types.test.ts  # PASS
```

Manual: verify glyphs remain legible at low zoom with overlapping edges in `full` and `category` modes. Minimal mode renders neutral solid lines without glyphs.

Closes #108