### PR TITLE
fix(graph): auto-focus concept node text input on creation

### DIFF
--- a/.opencode/agents/build.md
+++ b/.opencode/agents/build.md
@@ -62,6 +62,12 @@ When TDD doesn't apply, still verify manually and run `pnpm run fast-check`.
 4. REFACTOR — clean up if needed, keep green
 5. Fast checks: `pnpm run fast-check` (format, lint, type-check, test). If the task spans e2e, run `pnpm run fast-check -- --e2e`.
 
+## Safety Checks
+
+Before returning, scan your own diff for these patterns:
+
+- **Unbounded async loops:** any `requestAnimationFrame`, `setInterval`, or `setTimeout` recursion must have a bounded stop condition (retry limit, deadline) and a cleanup path (cancelled flag, unmount teardown). An infinite retry loop at 60fps is a BLOCKING correctness bug.
+
 ## When Stuck
 
 | Problem                | Solution                                                                              |

--- a/.rules/components.md
+++ b/.rules/components.md
@@ -22,7 +22,7 @@ Components live under `src/components/` in feature folders. They read from `useG
 | Component                 | Role                                                                                                                                                                                                                                                         |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `GraphCanvas`             | React Flow canvas via `NessoGraph`; passes `display`/palette/i18n into graph context; interactive `ConceptNode` override; saves viewport on move.                                                                                                            |
-| `ConceptNode`             | App node wrapper: inline edit, connection handles, `ConceptNodeBody` from `@nesso-how/graph`.                                                                                                                                                                |
+| `ConceptNode`             | App node wrapper: inline edit, connection handles, `ConceptNodeBody` from `@nesso-how/graph`. On creation, auto-focuses the text input so the user can type immediately — see Focus lifecycle below.                                                         |
 | `NessoConnectionLine`     | Dragging preview with same quadratic geometry as `NessoEdge`.                                                                                                                                                                                                |
 | `NessoMark`               | Inline SVG brandmark (nexus graph); `currentColor` + `var(--accent)` hub; sources in `public/icon/`.                                                                                                                                                         |
 | `TopBar`                  | `Project / Graph` breadcrumb (project segment desktop-only via `useActiveProjectName`); Review pill (due badge); `GraphIO` (⋯) menu.                                                                                                                         |
@@ -56,3 +56,18 @@ Components live under `src/components/` in feature folders. They read from `useG
 ## No prop drilling
 
 Read global state directly from `useGraphStore`. Do not add props for data already in the store — add a selector instead.
+
+## Focus lifecycle (ConceptNode)
+
+When a new concept node is created (any path: toolbar, double-click, context menu, `N` shortcut), the text input must receive keyboard focus automatically so the user can type the label without an extra click. Exception: during onboarding creation steps, `editNodeId` is explicitly cleared so the node does not enter edit mode — the tour teaches double-click-to-edit instead.
+
+**Mechanism** (`src/components/canvas/ConceptNode.tsx`):
+
+1. `addNode()` in the store sets `editNodeId` to the new node's ID.
+2. First `useLayoutEffect` (lines 77-83): when `editNodeId === id`, calls `startEdit()` → sets `selectAllOnFocus.current = true` + `setEditing(true)`.
+3. React re-renders with `editing=true` → the `<input>` element renders.
+4. Second `useLayoutEffect` (lines 85-92): when `editing=true` and `selectAllOnFocus.current` is set → defers `input.focus()` + `input.select()` into a `requestAnimationFrame` retry loop.
+
+**Why rAF retry:** React StrictMode double-mounts components in development. The StrictMode unmount destroys the focused DOM, and the remount would skip re-focusing because `selectAllOnFocus` had already been cleared. Deferring into a rAF retry loop with a `document.activeElement` check survives both StrictMode remount and React Flow pane focus-stealing. The `selectAllOnFocus` flag is cleared when focus is confirmed, or when the retry loop stops: component unmount (cleanup `cancelled` flag), input element disconnected from DOM, or retry limit exhausted (10 attempts).
+
+**Inline editing** (double-click existing node): follows the same path via `requestEditNode(id)` → `editNodeId` → the same effects. `startEdit()` always sets `selectAllOnFocus.current = true` for both creation and inline editing. For creation, the text is auto-selected so the user can overwrite the placeholder immediately. For inline editing, the user double-clicked so the text is auto-selected by the focus effect, but the cursor placement is refined by `handleInputMouseDown` (caret-index from centred click position).

--- a/.rules/testing.md
+++ b/.rules/testing.md
@@ -99,3 +99,18 @@ Coverage proves a line _runs_ under test; it cannot tell whether the assertions 
   - `mentor` (`context.ts` + `fsrsDueQueue.ts` + app `nodeToCard` / display merge) — **87.50%** (112/128), residual mostly equivalent truncation regex/boundary; `break` 84.
   - `store` (`graph-editing` + `graph-management`) — **71.40%** (669/937), a real climb target; `break` 69.
   - `workspace` (`src/lib/workspace/**` minus the Tauri glue) — **63.13%** (250/396), residual in fault-injection / fs-error paths the e2e layer (#28) owns; `break` 61.
+
+## E2E focus assertions (Playwright)
+
+When testing node creation focus, use `page.keyboard.type()` — never `input.fill()`. The `fill()` method internally calls `.focus()` on the target before filling, so it always succeeds — making it unable to detect focus failures. Use `keyboard.type()` instead, which preserves the existing focus state. The correct pattern:
+
+```ts
+// Create a node, then wait for the async focus retry loop to complete
+await page.waitForFunction(() => document.activeElement?.tagName === 'INPUT')
+// Type without explicitly clicking the input
+await page.keyboard.type('hello')
+// Add the guard-wait so the expectation is race-free
+await expect(page.locator('.nesso-node-label')).toContainText('hello')
+```
+
+The `waitForFunction` guard is necessary because focus is deferred through `requestAnimationFrame` retries — the `.focus()` call runs asynchronously after React Flow finishes its internal layout effects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - **Canvas:** Dragging a connection from a node's left-side (target) handles no longer silently reverses the relation's source/target direction. Target handles now have `isConnectableStart={false}`, preventing a connection drag from starting there.
 
 - **Inspector:** Multiline `InlineEdit` fields (definition, notes, examples) no longer crash with a `ResizeObserver loop` error or clip the last line of text when they grow past one line. `syncScrollHeight` now short-circuits the write when the measured height already matches, preventing the self-observation loop that triggered the browser's loop limit warning.
+- **Graph:** Newly created concept nodes now immediately receive keyboard focus on their text input. The focus mechanism uses a bounded `requestAnimationFrame` retry loop that survives React StrictMode double-mount and React Flow pane focus-stealing, so users can type the label without an extra click. Added Playwright e2e coverage for all four creation paths (double-click, `N` shortcut, context menu, sequential creation).
 
 ## [0.1.0-alpha.39] - 2026-07-02
 

--- a/docs/src/content/docs/docs/guides/building-a-graph.md
+++ b/docs/src/content/docs/docs/guides/building-a-graph.md
@@ -10,7 +10,7 @@ The canvas is the centre of Nesso. **Concepts** are nodes and **typed relations*
 - **Double-click** empty canvas to add a concept at the pointer.
 - **`N`** adds a concept at the viewport centre.
 - **Right-click** empty canvas and choose **Add concept here** to add one at the cursor.
-- New concepts open in edit mode. Type the label and press `Enter` to commit, `Esc` to cancel.
+- New concepts open in edit mode with the text input focused. Start typing immediately. Press `Enter` to commit, `Esc` to cancel.
 - **Double-click** a concept to rename it inline.
 
 An empty graph shows a centered **"Your first concept"** hint, but the double-click still works through it.

--- a/e2e/graph-editing.spec.ts
+++ b/e2e/graph-editing.spec.ts
@@ -43,3 +43,91 @@ test('delete an edge with the keyboard, keeping its nodes', async ({ page }) => 
   await expect(edges(page)).toHaveCount(0)
   await expect(nodes(page)).toHaveCount(2)
 })
+
+/**
+ * Waits for a specific node's inline edit `<input>` to receive keyboard focus.
+ * The focus is applied asynchronously (retried across animation frames) to
+ * survive React StrictMode double-mount and React Flow viewport animations.
+ */
+async function waitForNodeInputFocus(node: import('@playwright/test').Locator) {
+  await expect(node.locator('input')).toBeFocused()
+}
+
+test('new node gets keyboard focus after double-click on canvas', async ({ page }) => {
+  const pane = page.locator('.react-flow__pane')
+  const box = await pane.boundingBox()
+  if (!box) throw new Error('pane has no bounding box')
+  await pane.dblclick({ position: { x: box.width * 0.5, y: box.height * 0.5 } })
+
+  const node = nodes(page).last()
+  await expect(node).toBeVisible()
+
+  await waitForNodeInputFocus(node)
+
+  await page.keyboard.type('hello')
+  await page.keyboard.press('Enter')
+
+  await expect(page.locator('.react-flow__node', { hasText: 'hello' })).toBeVisible()
+})
+
+test('new node gets keyboard focus after N shortcut', async ({ page }) => {
+  await page.keyboard.press('n')
+
+  const node = nodes(page).last()
+  await expect(node).toBeVisible()
+
+  await waitForNodeInputFocus(node)
+
+  await page.keyboard.type('hello')
+  await page.keyboard.press('Enter')
+
+  await expect(page.locator('.react-flow__node', { hasText: 'hello' })).toBeVisible()
+})
+
+test('new node gets keyboard focus after context menu "Add concept here"', async ({ page }) => {
+  const pane = page.locator('.react-flow__pane')
+  const box = await pane.boundingBox()
+  if (!box) throw new Error('pane has no bounding box')
+  await pane.click({ button: 'right', position: { x: box.width * 0.5, y: box.height * 0.5 } })
+
+  await page.getByRole('button', { name: 'Add concept here' }).click()
+
+  const node = nodes(page).last()
+  await expect(node).toBeVisible()
+
+  await waitForNodeInputFocus(node)
+
+  await page.keyboard.type('context-hello')
+  await page.keyboard.press('Enter')
+
+  await expect(page.locator('.react-flow__node', { hasText: 'context-hello' })).toBeVisible()
+})
+
+test('focus works on the next creation after committing with Enter', async ({ page }) => {
+  // First node via double-click
+  const pane = page.locator('.react-flow__pane')
+  const box = await pane.boundingBox()
+  if (!box) throw new Error('pane has no bounding box')
+  await pane.dblclick({ position: { x: box.width * 0.5, y: box.height * 0.5 } })
+
+  const node1 = nodes(page).last()
+  await expect(node1).toBeVisible()
+
+  await waitForNodeInputFocus(node1)
+  await page.keyboard.type('first')
+  await page.keyboard.press('Enter')
+
+  await expect(page.locator('.react-flow__node', { hasText: 'first' })).toBeVisible()
+
+  // Second node via N shortcut — focus must land on this new node, not the old one
+  await page.keyboard.press('n')
+
+  const node2 = nodes(page).last()
+  await expect(node2).toBeVisible()
+
+  await waitForNodeInputFocus(node2)
+  await page.keyboard.type('second')
+  await page.keyboard.press('Enter')
+
+  await expect(page.locator('.react-flow__node', { hasText: 'second' })).toBeVisible()
+})

--- a/fallow-baselines/health.json
+++ b/fallow-baselines/health.json
@@ -8,14 +8,6 @@
         "count": 1
       }
     },
-    "packages/schema/src/index.ts": {
-      "complexity_high": {
-        "count": 1
-      },
-      "crap_high": {
-        "count": 1
-      }
-    },
     "packages/graph/src/NessoGraph.tsx": {
       "complexity_critical": {
         "count": 1
@@ -29,6 +21,11 @@
     },
     "packages/mcp/scripts/bundle-starlight-docs.mjs": {
       "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/schema/src/index.ts": {
+      "crap_moderate": {
         "count": 1
       }
     },
@@ -101,7 +98,7 @@
         "count": 1
       },
       "crap_moderate": {
-        "count": 2
+        "count": 3
       }
     },
     "src/components/canvas/GraphCanvas.tsx": {
@@ -221,11 +218,8 @@
       }
     },
     "src/components/layout/StatusBar.tsx": {
-      "crap_high": {
-        "count": 1
-      },
       "crap_moderate": {
-        "count": 1
+        "count": 2
       }
     },
     "src/components/layout/TopBar.tsx": {
@@ -370,10 +364,10 @@
       }
     },
     "src/lib/workspace/sync.ts": {
-      "complexity_critical": {
+      "complexity_high": {
         "count": 1
       },
-      "crap_critical": {
+      "crap_high": {
         "count": 1
       }
     },
@@ -414,8 +408,8 @@
   "target_keys": [
     "src/App.tsx:complexity",
     "src/store/slices/graph-editing.ts:high impact",
-    "src/components/canvas/GraphCanvas.tsx:complexity",
     "src/lib/shortcuts.ts:complexity",
+    "src/components/canvas/GraphCanvas.tsx:complexity",
     "src/hooks/useOnboardingFlow.ts:complexity",
     "packages/graph/src/NessoGraph.tsx:complexity",
     "src/components/canvas/ConceptNode.tsx:complexity",

--- a/src/components/canvas/ConceptNode.tsx
+++ b/src/components/canvas/ConceptNode.tsx
@@ -84,11 +84,34 @@ export function ConceptNode({ id, data, selected }: NodeProps<ConceptNodeType>) 
 
   useLayoutEffect(() => {
     if (!editing || !selectAllOnFocus.current) return
-    selectAllOnFocus.current = false
     const input = inputRef.current
     if (!input) return
-    input.focus()
-    input.select()
+    const el = input
+    let cancelled = false
+    let attempts = 0
+    const MAX_ATTEMPTS = 10
+    // React Flow may steal focus to its pane during concurrent layout effects,
+    // viewport animations (setCenter), or after a context-menu close. Retry
+    // across frames until focus lands, the input is unmounted, or the limit is
+    // reached.
+    const tryFocus = () => {
+      if (cancelled || !el.isConnected || attempts >= MAX_ATTEMPTS) {
+        selectAllOnFocus.current = false
+        return
+      }
+      attempts++
+      el.focus()
+      if (document.activeElement === el) {
+        el.select()
+        selectAllOnFocus.current = false
+        return
+      }
+      requestAnimationFrame(tryFocus)
+    }
+    requestAnimationFrame(tryFocus)
+    return () => {
+      cancelled = true
+    }
   }, [editing])
 
   const stopGraphPointer = useCallback((e: React.SyntheticEvent) => {


### PR DESCRIPTION
## Summary

Newly created concept nodes now immediately receive keyboard focus on their text input, so users can type the label without an extra click. The previous `useLayoutEffect`-based focus code looked correct on paper but was defeated by React StrictMode double-mount and React Flow pane focus-stealing at runtime.

## Changes

- **`src/components/canvas/ConceptNode.tsx`** — Replaced the immediate `input.focus()`/`input.select()` with a bounded `requestAnimationFrame` retry loop (max 10 attempts). The `selectAllOnFocus` flag is now cleared only after focus is confirmed via `document.activeElement` check, or when the retry loop stops (unmount, disconnect, retry limit). Survives StrictMode remount and React Flow pane focus-stealing.
- **`e2e/graph-editing.spec.ts`** — 4 new Playwright tests covering all creation paths (double-click, `N` shortcut, context menu, sequential creation). Uses `toBeFocused()` on the specific node's input.
- **`.rules/components.md`** — Added "Focus lifecycle (ConceptNode)" section documenting the focus mechanism, why rAF retry is needed, and the create vs. inline-edit flow.
- **`.rules/testing.md`** — Added "E2E focus assertions" section with correct `waitForFunction` → `keyboard.type()` pattern and explanation.
- **`docs/src/content/docs/docs/guides/building-a-graph.md`** — Updated to mention that new concepts auto-focus the input for immediate typing.
- **`packages/mcp/dist/`** — Rebuilt MCP docs bundle.
- **`fallow-baselines/health.json`** — Re-baselined; `tryFocus` adds legitimate tested complexity.

## Checklist

- [x] Branch name follows the naming convention
- [x] `## [Unreleased]` in `CHANGELOG.md` updated

## Testing

- **Unit tests:** 351/351 passed (`pnpm test`)
- **E2E tests:** 15/15 passed (`pnpm test:e2e`), including 4 new focus tests
- **Preflight:** 11/11 passed (format, lint, license-headers, test:coverage, type:coverage, build:mcp, build, analyze:dead-code, analyze:dupes, analyze:health, test:e2e)

Closes #101