### PR TITLE
fix(store): recall heatmap defaults to off on startup and failed load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - **Inspector:** Multiline `InlineEdit` fields (definition, notes, examples) no longer crash with a `ResizeObserver loop` error or clip the last line of text when they grow past one line. `syncScrollHeight` now short-circuits the write when the measured height already matches, preventing the self-observation loop that triggered the browser's loop limit warning.
 - **Graph:** Newly created concept nodes now immediately receive keyboard focus on their text input. The focus mechanism uses a bounded `requestAnimationFrame` retry loop that survives React StrictMode double-mount and React Flow pane focus-stealing, so users can type the label without an extra click. Added Playwright e2e coverage for all four creation paths (double-click, `N` shortcut, context menu, sequential creation).
 
+- **Heatmap:** The recall heatmap no longer briefly flashes on during app startup or persists incorrectly when a graph load fails. Store initialization now passes the app settings into the display helper so the canvas starts with the correct default, and a failed `loadGraph` resets stale heatmap state to the current setting. Overlapping load requests are guarded against stale async writes.
+
 ## [0.1.0-alpha.39] - 2026-07-02
 
 ### Changed

--- a/fallow-baselines/health.json
+++ b/fallow-baselines/health.json
@@ -133,10 +133,10 @@
     },
     "src/components/dialogs/RelationTypesDialog.tsx": {
       "crap_high": {
-        "count": 2
+        "count": 1
       },
       "crap_moderate": {
-        "count": 1
+        "count": 2
       }
     },
     "src/components/dialogs/SearchDialog.tsx": {
@@ -387,7 +387,7 @@
         "count": 1
       },
       "crap_moderate": {
-        "count": 1
+        "count": 2
       }
     },
     "src/telemetry/index.ts": {
@@ -414,9 +414,9 @@
     "packages/graph/src/NessoGraph.tsx:complexity",
     "src/components/canvas/ConceptNode.tsx:complexity",
     "src/components/mentor/MentorPanel.tsx:complexity",
+    "src/components/inspector/InlineEdit.tsx:complexity",
     "src/components/inspector/NodeInspector.tsx:complexity",
     "src/components/review/ReviewMode.tsx:complexity",
-    "src/components/inspector/InlineEdit.tsx:complexity",
     "scripts/release.mjs:complexity"
   ]
 }

--- a/src/store/slices/graph-management.test.ts
+++ b/src/store/slices/graph-management.test.ts
@@ -1,15 +1,38 @@
 // @vitest-environment jsdom
 // SPDX-License-Identifier: MIT
 import 'fake-indexeddb/auto'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createStore } from 'zustand/vanilla'
-import { dbClearGraphs, dbListGraphs, dbLoadGraph } from '@/store/db'
+import { dbClearGraphs, dbListGraphs, dbLoadGraph, dbSaveGraph } from '@/store/db'
+import type { GraphRecord } from '@/store/db'
 import type { GraphState } from '../state'
 import { createDesktopSyncSlice } from './desktop-sync'
 import { createGraphEditingSlice } from './graph-editing'
 import { createGraphManagementSlice } from './graph-management'
 import { createSettingsSlice } from './settings'
 import { createUISlice } from './ui'
+
+// Controlled override for dbLoadGraph — set per-test to intercept load timing.
+// Use vi.hoisted so the references are available in the hoisted vi.mock factory.
+const { dbLoadGraphOverrideRef, realDbLoadGraphRef } = vi.hoisted(() => ({
+  dbLoadGraphOverrideRef: {
+    current: null as ((id: string) => Promise<GraphRecord | undefined>) | null,
+  },
+  realDbLoadGraphRef: { current: null as typeof dbLoadGraph | null },
+}))
+
+vi.mock('@/store/db', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/store/db')>()
+  realDbLoadGraphRef.current = original.dbLoadGraph
+  return {
+    ...original,
+    dbLoadGraph: vi.fn((id: string) => {
+      const override = dbLoadGraphOverrideRef.current
+      if (override) return override(id)
+      return original.dbLoadGraph(id)
+    }),
+  }
+})
 
 // Web mode: `isDesktop()` is false under jsdom, so graph management persists
 // through IndexedDB only — no disk/Tauri involved. Graphs live in a real
@@ -28,6 +51,15 @@ function makeStore() {
 }
 
 type Store = ReturnType<typeof makeStore>
+
+describe('store display initialization', () => {
+  it('starts the active graph display with the app heatmap default', () => {
+    const s = makeStore()
+
+    expect(s.getState().settings.showHeatmap).toBe(false)
+    expect(s.getState().graphDisplay.showHeatmap).toBe(false)
+  })
+})
 
 async function freshStore(): Promise<Store> {
   const s = makeStore()
@@ -83,6 +115,7 @@ describe('createGraph', () => {
     expect(state.currentGraphId).toBe(id)
     expect(state.graphList.some((g) => g.id === id && g.name === 'Fresh')).toBe(true)
     expect(state.nodes).toHaveLength(0)
+    expect(state.graphDisplay.showHeatmap).toBe(false)
     const stored = await dbLoadGraph(id)
     expect(stored).toMatchObject({ id, name: 'Fresh' })
   })
@@ -189,6 +222,88 @@ describe('loadGraph', () => {
     await s.getState().loadGraph('does-not-exist')
     expect(s.getState().currentGraphId).toBe(before)
     expect(s.getState().nodes).toHaveLength(0)
+  })
+
+  it('uses the current app heatmap default when a stored graph has no display', async () => {
+    const s = makeStore()
+    const id = 'g-no-display'
+
+    s.getState().setSetting('showHeatmap', true)
+    await dbSaveGraph({
+      id,
+      name: 'No display',
+      createdAt: 1,
+      updatedAt: 1,
+      nodes: [],
+      edges: [],
+    })
+
+    await s.getState().loadGraph(id)
+
+    expect(s.getState().graphDisplay.showHeatmap).toBe(true)
+  })
+
+  it('resets the heatmap to the current app default when the graph is missing', async () => {
+    const s = makeStore()
+
+    s.getState().setSetting('showHeatmap', true)
+    s.getState().setGraphDisplay('showHeatmap', false)
+
+    await s.getState().loadGraph('does-not-exist')
+
+    expect(s.getState().graphDisplay.showHeatmap).toBe(true)
+  })
+
+  it('does not overwrite the active graph when a missing-graph load resolves after a successful one', async () => {
+    const s = makeStore()
+    await s.getState().loadGraphList()
+
+    const validId = await s.getState().createGraph('Valid')
+    s.getState().addNode(50, 50)
+    // Persist the graph with showHeatmap differing from the app default.
+    s.getState().setGraphDisplay('showHeatmap', false)
+    await s.getState().saveCurrentGraph()
+
+    // Switch the app default to the opposite value so the missing-graph path
+    // would clobber the loaded graph's display if it races.
+    s.getState().setSetting('showHeatmap', true)
+
+    // Create a deferred promise so we control when the "missing" call resolves.
+    let resolveMissing!: (value: GraphRecord | undefined) => void
+    const missingPromise = new Promise<GraphRecord | undefined>((resolve) => {
+      resolveMissing = resolve
+    })
+
+    // Intercept dbLoadGraph: delay the missing-graph call, pass through for valid ids.
+    dbLoadGraphOverrideRef.current = async (id: string) => {
+      if (id === 'fake-missing') return missingPromise
+      return realDbLoadGraphRef.current!(id)
+    }
+
+    // Start the missing load (NOT awaited — it's blocked on the deferred promise).
+    const missingLoad = s.getState().loadGraph('fake-missing')
+
+    // Start and await the valid load. It should complete first.
+    await s.getState().loadGraph(validId)
+
+    // The state must reflect the successfully loaded valid graph.
+    expect(s.getState().currentGraphId).toBe(validId)
+    expect(s.getState().nodes).toHaveLength(1)
+    expect(s.getState().graphDisplay.showHeatmap).toBe(false)
+
+    // Now let the missing-graph call resolve. Without the token guard, this
+    // would reset showHeatmap to the app default (true), clobbering the loaded
+    // graph's stored display.
+    resolveMissing(undefined)
+    await missingLoad
+
+    // State must still reflect the valid graph — the stale missing-graph
+    // response must be discarded.
+    expect(s.getState().currentGraphId).toBe(validId)
+    expect(s.getState().nodes).toHaveLength(1)
+    expect(s.getState().graphDisplay.showHeatmap).toBe(false)
+
+    dbLoadGraphOverrideRef.current = null
   })
 })
 

--- a/src/store/slices/graph-management.ts
+++ b/src/store/slices/graph-management.ts
@@ -57,6 +57,9 @@ let _switchProjectInflight: Promise<GraphMeta[]> | null = null
 // Set while abandoning a project whose folder was deleted externally — any
 // save in that window would silently recreate the folder from the IDB cache.
 let _suppressOutgoingSave = false
+// Monotonic counter for loadGraph race prevention — the most recently started
+// call wins, older ones are discarded. Has no semantic meaning beyond this.
+let _loadRequestId = 0
 
 /** Register `path` as the most-recent known project, then switch to it. */
 function registerAndSwitch(
@@ -488,10 +491,21 @@ export const createGraphManagementSlice: StateCreator<GraphState, [], [], GraphM
     ) {
       await s.saveCurrentGraph()
     }
+    // Capture a monotonic request id so the most-recently-started loadGraph
+    // wins and older ones are discarded across every async gap below.
+    const requestId = ++_loadRequestId
     const record = await dbLoadGraph(id)
-    if (!record) return
+    if (requestId !== _loadRequestId) return
+    if (!record) {
+      const showHeatmap = defaultGraphDisplay(get().settings).showHeatmap
+      set((s) => ({
+        graphDisplay: { ...s.graphDisplay, showHeatmap },
+      }))
+      return
+    }
     _draggingNodeIds.clear()
     const reviews = await dbGetReviewStatesForGraph(id)
+    if (requestId !== _loadRequestId) return
     const nodes = record!.nodes.map((n) => mergeReviewIntoNode(n, reviews.get(n.id)))
     const graphDisplay = mergeGraphDisplay(record!.display, get().settings)
     const fp = graphContentFingerprint(nodes, record!.edges, graphDisplay)

--- a/src/store/slices/settings.ts
+++ b/src/store/slices/settings.ts
@@ -15,8 +15,8 @@ export interface SettingsSlice {
   ) => void
 }
 
-export const createSettingsSlice: StateCreator<GraphState, [], [], SettingsSlice> = (set) => ({
-  settings: {
+export const createSettingsSlice: StateCreator<GraphState, [], [], SettingsSlice> = (set) => {
+  const settings: NessoSettings = {
     dark: false,
     language: 'en' as const,
     edgeEncoding: 'full',
@@ -39,21 +39,25 @@ export const createSettingsSlice: StateCreator<GraphState, [], [], SettingsSlice
     telemetry: false,
     onboardingCompleted: false,
     telemetryPromptShown: false,
-  },
-  graphDisplay: defaultGraphDisplay(),
+  }
 
-  setSetting: (key, value) => set((s) => ({ settings: { ...s.settings, [key]: value } })),
+  return {
+    settings,
+    graphDisplay: defaultGraphDisplay(settings),
 
-  setGraphDisplay: (key, value) =>
-    set((s) => {
-      const graphDisplay = { ...s.graphDisplay, [key]: value }
-      if (key === 'autoCurveFlip' && value === false && s.graphDisplay.autoCurveFlip) {
-        return {
-          ...pushHistory(s),
-          graphDisplay,
-          edges: bakeCurveFlipFromPositions(s.edges, s.nodes),
+    setSetting: (key, value) => set((s) => ({ settings: { ...s.settings, [key]: value } })),
+
+    setGraphDisplay: (key, value) =>
+      set((s) => {
+        const graphDisplay = { ...s.graphDisplay, [key]: value }
+        if (key === 'autoCurveFlip' && value === false && s.graphDisplay.autoCurveFlip) {
+          return {
+            ...pushHistory(s),
+            graphDisplay,
+            edges: bakeCurveFlipFromPositions(s.edges, s.nodes),
+          }
         }
-      }
-      return { graphDisplay }
-    }),
-})
+        return { graphDisplay }
+      }),
+  }
+}


### PR DESCRIPTION
## Summary

The recall heatmap displayed as enabled for a window of time on startup (worse on Desktop) even though the app default is off. On Desktop with a slow startup path, this could be clearly visible or permanent if graph load silently failed.

## Changes

- **Store init:** Pass app settings into `defaultGraphDisplay(settings)` instead of calling it with no arguments, so `graphDisplay.showHeatmap` starts as `false` matching the app default.
- **Failed load:** When `loadGraph` finds no record, reset `graphDisplay.showHeatmap` to the current app setting instead of leaving stale state.
- **Race guard:** `_loadRequestId` monotonic counter prevents overlapping `loadGraph` calls from overwriting each other's results — checked after both `dbLoadGraph` and `dbGetReviewStatesForGraph` async gaps.
- **Tests:** Store init assertion, stored-graph-without-display path, missing-graph reset, race condition guard, and createGraph heatmap default.

## Checklist

- [x] Branch name follows the naming convention
- [x] `## [Unreleased]` in `CHANGELOG.md` updated

## Testing

- 30 unit tests pass (`graph-management` + `settings` suites)
- Playwright e2e: 18/18 green
- Preflight: format, lint, license-headers, type:coverage, build all pass

Closes #96