### PR TITLE
chore(harness): tighten agent permissions and add worktree path-safety

### DIFF
--- a/.opencode/agents/brainstorm.md
+++ b/.opencode/agents/brainstorm.md
@@ -1,8 +1,12 @@
 ---
 mode: primary
 permission:
+  bash:
+    git commit *: deny
+    git push *: deny
+    rm *: deny
+    '*': allow
   edit: deny
-  bash: ask
   task: deny
 description: Interactive design exploration through dialogue. Questions, alternatives, approval gates. Never writes code.
 ---

--- a/.opencode/agents/build.md
+++ b/.opencode/agents/build.md
@@ -1,8 +1,13 @@
 ---
 mode: subagent
 permission:
+  bash:
+    git commit *: deny
+    git push *: deny
+    rm *: deny
+    '*': allow
   edit: allow
-  bash: allow
+  task: allow
 description: Executes one task from an implementation plan using RED-GREEN-REFACTOR TDD. Dispatched by the work agent per task. No user interaction.
 ---
 

--- a/.opencode/agents/fix.md
+++ b/.opencode/agents/fix.md
@@ -1,8 +1,12 @@
 ---
 mode: primary
 permission:
+  bash:
+    git commit *: deny
+    git push *: deny
+    rm *: deny
+    '*': allow
   edit: deny
-  bash: ask
   task: deny
 description: Bug root-cause analysis through forensic dialogue. Reproduce, trace, explain — then feed into planning. Never patches.
 ---

--- a/.opencode/agents/guard-review.md
+++ b/.opencode/agents/guard-review.md
@@ -2,8 +2,14 @@
 description: Semantic constraint guard for Nesso. Read the diff against AGENTS.md Constraints + .rules/ conventions + cross-cutting obligations. Read-only — reports findings, does not edit. Dispatched by the review skill alongside quality-review.
 mode: subagent
 permission:
+  bash:
+    git commit *: deny
+    git push *: deny
+    git checkout *: deny
+    rm *: deny
+    '*': allow
   edit: deny
-  bash: allow
+  task: deny
 ---
 
 You are the Nesso constraint guard. Review the current change — by default the working-tree diff plus `git diff origin/main...HEAD` — ONLY against this repo's hard constraints, conventions, and cross-cutting obligations. You never edit; you report findings with `file:line` evidence, grouped by severity.

--- a/.opencode/agents/harness.md
+++ b/.opencode/agents/harness.md
@@ -1,8 +1,12 @@
 ---
 mode: primary
 permission:
+  bash:
+    git commit *: deny
+    git push *: deny
+    rm *: deny
+    '*': allow
   edit: allow
-  bash: allow
   task: deny
 description: Harness lifecycle — coherence sweeps, restructuring, rule maintenance, and migration. Owns `.rules/harness.md` as source of truth.
 ---
@@ -13,7 +17,7 @@ You are the harness agent. You manage the AI coding scaffolding: the rules, the 
 
 You are a **primary** agent — the user invokes you directly for sweeps, restructuring, and harness maintenance. You are not dispatched as a subagent.
 
-Your source of truth is [`.rules/harness.md`](../../.rules/harness.md). Read it first — its invariants define what "coherent" means. For construct selection (when to use a rule vs skill vs agent vs script), see that file.
+Your source of truth is `.rules/harness.md` in the active worktree. Read it first — its invariants define what "coherent" means. For construct selection (when to use a rule vs skill vs agent vs script), see that file.
 
 ## What You Do
 
@@ -27,12 +31,13 @@ Read-only by default; never commit or push (see AGENTS.md → Git). Use when:
 
 #### Method
 
-1. **Read `.rules/harness.md` in full.** It is the checklist. If reality and the rule disagree, the rule wins; if the rule and this procedure disagree, that is itself a finding (update one of them).
-2. **Enumerate the git-tracked surfaces** — the Scope invariant means tracked files only:
+1. **Verify the active worktree** — run `git rev-parse --show-toplevel` before reading files. Use that returned path as the source root; never pass file-relative `../` link targets directly to tools.
+2. **Read `.rules/harness.md` in full.** It is the checklist. If reality and the rule disagree, the rule wins; if the rule and this procedure disagree, that is itself a finding (update one of them).
+3. **Enumerate the git-tracked surfaces** — the Scope invariant means tracked files only:
    ```bash
    git ls-files .rules .opencode opencode.json AGENTS.md
    ```
-3. **Walk each invariant** and verify it against that evidence — rules ↔ AGENTS.md agreement, Touch → update coverage, skill/subagent validity, link resolution. Read the actual files; do not assume.
+4. **Walk each invariant** and verify it against that evidence — rules ↔ AGENTS.md agreement, Touch → update coverage, skill/subagent validity, link resolution. Read the actual files; do not assume.
 
 #### Judgment traps — why this is a sweep, not a script
 
@@ -102,14 +107,9 @@ These are the files you govern. Everything else is product code.
 | Skills         | `.opencode/skills/<name>/SKILL.md` |
 | MCP config     | `opencode.json` → `mcp`            |
 
-## Invariants (summary — see `.rules/harness.md` for full definitions)
+## Invariants
 
-1. **Rules ↔ AGENTS.md bijection** — every `.rules/<name>.md` is listed in Area rules, every list entry has a matching file.
-2. **Touch → update coverage** — same set as Area rules, with valid globs.
-3. **Link resolution** — all intra-rules and AGENTS.md → rules links resolve.
-4. **Skill/subagent validity** — frontmatter is correct, no orphaned files.
-5. **MCP in opencode.json** — single declaration point, no duplicates.
-6. **Scripts over skills** — deterministic work is a script, not a skill.
+See `.rules/harness.md` for the complete invariant definitions and audit criteria.
 
 ## Session Boundaries
 

--- a/.opencode/agents/plan.md
+++ b/.opencode/agents/plan.md
@@ -1,8 +1,15 @@
 ---
 mode: subagent
 permission:
-  edit: allow
-  bash: allow
+  bash:
+    git commit *: deny
+    git push *: deny
+    rm *: deny
+    '*': allow
+  edit:
+    .plans/*: allow
+    '*': deny
+  task: allow
 description: Reads an approved GitHub issue and produces a bite-sized implementation plan. Dispatched by the work agent. No user interaction — pure input-to-output.
 ---
 

--- a/.opencode/agents/quality-review.md
+++ b/.opencode/agents/quality-review.md
@@ -2,8 +2,14 @@
 description: Universal code quality review. Read the diff for bugs, security issues, over-engineering, duplication, and performance problems. Read-only — reports findings, does not edit. Dispatched by the review skill alongside guard-review.
 mode: subagent
 permission:
+  bash:
+    git commit *: deny
+    git push *: deny
+    git checkout *: deny
+    rm *: deny
+    '*': allow
   edit: deny
-  bash: allow
+  task: deny
 ---
 
 You are a universal code quality reviewer. Review the current change — by default the working-tree diff plus `git diff origin/main...HEAD` — for correctness, security, design, and performance. You never edit; you report findings with `file:line` evidence, grouped by severity.

--- a/.opencode/agents/work.md
+++ b/.opencode/agents/work.md
@@ -1,8 +1,12 @@
 ---
 mode: primary
 permission:
+  bash:
+    git commit *: deny
+    git push *: deny
+    rm *: deny
+    '*': allow
   edit: deny
-  bash: allow
   task: allow
 description: Post-issue orchestrator. Routes the development flow from planning to PR. Dispatches plan, build subagents and loads the review skill at the review phase. Creates PR via skill after review passes. Asks for user approval at gates. Never writes code directly.
 ---
@@ -73,7 +77,7 @@ GitHub Issue → plan (subagent) → [user approves plan]
 
 4. **If the user opts for a plan**: dispatch `plan` to write `.plans/<issue-number>-review-<N>.md` (where N counts review cycles: `94-review-1.md`, `94-review-2.md`, …). The original `.plans/<issue-number>.md` is never overwritten — it stays as the first-draft record. The review plan receives the review findings and the current diff as input. After user approves the review plan → dispatch `build` per task → preflight → review → loop at step 3.
 5. **If the user confirms build directly**: dispatch `build` for each suggested fix, then re-run preflight and re-run review. If the new review still has findings, loop at step 3 again (increment N).
-6. **If ready to PR** → update `## [Unreleased]` in `CHANGELOG.md` per [`.rules/changelog.md`](../../.rules/changelog.md), then load the **`create-pr`** skill with `--auto` and follow it — commit, push, open PR, enable auto-merge. The summary approval is the only gate; `create-pr` proceeds without further confirmation.
+6. **If ready to PR** → update `## [Unreleased]` in `CHANGELOG.md` per `.rules/changelog.md`, then load the **`create-pr`** skill with `--auto` and follow it — commit, push, open PR, enable auto-merge. The summary approval is the only gate; `create-pr` proceeds without further confirmation.
 
 ## Phase Table
 
@@ -93,7 +97,7 @@ GitHub Issue → plan (subagent) → [user approves plan]
 
 ## Constraints
 
-All hard rules live in [AGENTS.md → Constraints](../../AGENTS.md#constraints--hard-rules-never-do-this). Every subagent is instructed to respect them, but you are the final gate — if a subagent misses something, you catch it.
+All hard rules live in `AGENTS.md` → **Constraints**. Every subagent is instructed to respect them, but you are the final gate — if a subagent misses something, you catch it.
 
 ## Red Flags
 

--- a/.opencode/skills/create-pr/SKILL.md
+++ b/.opencode/skills/create-pr/SKILL.md
@@ -19,14 +19,14 @@ If a PR exists, use `gh pr edit` instead of `gh pr create`.
 
 ## Gotchas
 
-- **Never a lone "Test plan" block** — four `##` sections from [`.github/PULL_REQUEST_TEMPLATE.md`](../../../.github/PULL_REQUEST_TEMPLATE.md), in template order.
+- **Never a lone "Test plan" block** — four `##` sections from `.github/PULL_REQUEST_TEMPLATE.md`, in template order.
 - **Changes must describe the diff against `main`**, not a summary of PR commits. Run `git diff main...HEAD --stat` to see what changed; describe logical units, not commit messages.
 - **One closing keyword per issue** (`Closes #31, #26` closes only `#31`). Keyword must directly precede `#N`. Commit-message keywords do not populate the PR linked-issues panel — put them in the **body**.
 - **Rename branch only before the PR exists** — after open, rename+push auto-closes the PR. Rename worktree branches (`opencode/<random>` → `feat/<name>`) before first push.
 
 ## 1. Prepare the draft
 
-Branch: [CONTRIBUTING.md](../../../CONTRIBUTING.md) prefix (`feat/`, `fix/`, `refactor/`, `chore/`) + kebab-case. Body: fill template (strip HTML comments); mark checklist `[x]` only when true — [`.rules/changelog.md`](../../../.rules/changelog.md) for `[Unreleased]`. Title: conventional-commit style.
+Branch: `CONTRIBUTING.md` prefix (`feat/`, `fix/`, `refactor/`, `chore/`) + kebab-case. Body: fill template (strip HTML comments); mark checklist `[x]` only when true — `.rules/changelog.md` for `[Unreleased]`. Title: conventional-commit style.
 
 ## 2. Rebase onto `main`
 

--- a/.opencode/skills/preflight/SKILL.md
+++ b/.opencode/skills/preflight/SKILL.md
@@ -17,7 +17,7 @@ Appends the `rust` CI job (icons:desktop, cargo fmt/clippy/check/test) after the
 
 ### Native e2e (tauri-driver, local-only, not in CI)
 
-Opt-in when the diff touches desktop persistence, fs sync, or the file watcher. See [`.rules/testing.md`](../../.rules/testing.md).
+Opt-in when the diff touches desktop persistence, fs sync, or the file watcher. See `.rules/testing.md`.
 
 ```bash
 e2e-native/run-local.sh            # Docker (recommended)
@@ -42,12 +42,12 @@ When a step fails, fix and re-run individually:
 | `format:check`          | `pnpm run format`                                                                         |
 | `lint`                  | `pnpm run lint:fix`                                                                       |
 | `license-headers:check` | `pnpm run license-headers`                                                                |
-| `test:coverage`         | see [`.rules/testing.md`](../../.rules/testing.md) — ratchet gate                         |
+| `test:coverage`         | see `.rules/testing.md` — ratchet gate                                                    |
 | `type:coverage`         | fix type errors; thresholds in tsconfig                                                   |
 | `build`                 | fix compile errors                                                                        |
 | `analyze:dead-code`     | remove unused files/exports                                                               |
-| `analyze:dupes`         | see [`.rules/static-analysis.md`](../../.rules/static-analysis.md) — baseline-gated       |
-| `analyze:health`        | see [`.rules/static-analysis.md`](../../.rules/static-analysis.md) — baseline-gated       |
+| `analyze:dupes`         | see `.rules/static-analysis.md` — baseline-gated                                          |
+| `analyze:health`        | see `.rules/static-analysis.md` — baseline-gated                                          |
 | `test:e2e`              | check Playwright output; `pnpm exec playwright install --with-deps chromium` if first run |
 | `icons:desktop`         | `pnpm run icons:desktop`                                                                  |
 | `cargo:fmt`             | `cargo fmt --all --manifest-path src-tauri/Cargo.toml`                                    |

--- a/.opencode/skills/release/SKILL.md
+++ b/.opencode/skills/release/SKILL.md
@@ -7,9 +7,9 @@ description: Use when the user asks to cut, ship, publish, or version-bump a rel
 
 `scripts/release.mjs` (`pnpm release`) does the deterministic prep — the version bump across all nine files, the CHANGELOG roll, the lockfile refresh, and `build`/`lint`/`format:check`. This skill **drives that script and supervises it**: it owns the judgment the script can't make (which version, what ships, when to publish) and closes the gaps the script deliberately leaves open (the git push, branch protection, worktrees).
 
-Pushing the `v*` tag triggers [`.github/workflows/release.yml`](../../../.github/workflows/release.yml): npm publish of the workspace packages (Trusted Publishing / OIDC), a signed universal macOS `.dmg` desktop build, and a GitHub Release. **The tag push is the point of no return — it publishes to the public. Confirm with the user before step 4.**
+Pushing the `v*` tag triggers `.github/workflows/release.yml`: npm publish of the workspace packages (Trusted Publishing / OIDC), a signed universal macOS `.dmg` desktop build, and a GitHub Release. **The tag push is the point of no return — it publishes to the public. Confirm with the user before step 4.**
 
-For the conventions and the desktop auto-update / minisign signing details, see [`.rules/changelog.md`](../../../.rules/changelog.md); this skill executes that flow, it does not restate it.
+For the conventions and the desktop auto-update / minisign signing details, see `.rules/changelog.md`; this skill executes that flow, it does not restate it.
 
 ## 0. Preconditions
 

--- a/.rules/harness.md
+++ b/.rules/harness.md
@@ -45,6 +45,10 @@ If a task needs no AI judgment, write a script — not a skill. Skills burn toke
 - Links from `AGENTS.md` into `.rules/` resolve.
 - Source references named in rules (paths like `src/…`, package files, exported symbols) point to things that still exist. This is the part most exposed to drift during a restructuring, and the one only judgment can catch — a moved or renamed symbol still reads as a valid link.
 
+### Worktree-rooted tool paths
+
+The active Git worktree is the only source checkout agents should inspect or modify. Before planning, review, or subagent dispatch, verify it with `git rev-parse --show-toplevel` and resolve tool paths from that returned root. A Markdown link target such as `../../AGENTS.md` is relative to the Markdown file that contains it; it must not be passed verbatim to a tool whose current directory is the worktree. If a requested source path resolves outside the active worktree, stop and report the mismatch rather than inspecting the parent checkout.
+
 ## Scope — only git-tracked scaffolding
 
 A file is a harness surface only if it is **tracked in git**. Whatever is gitignored is out of scope by construction — machine-local worktrees, `*.local` config — so there is no exclusion list to keep current; git already draws the line.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,10 @@ Monorepo: `src/` (app) + `packages/` (`@nesso-how/*`). Desktop shell is optional
 
 For any non-trivial task, switch to the **`work`** agent — it orchestrates the 5-phase flow (brainstorm/plan → build → review → documentation), dispatches subagents for each phase, and enforces Nesso's constraints. Starting points: `brainstorm` for features, `fix` for bugs, then `work` for everything else.
 
+## Worktree and path safety
+
+When OpenCode runs in a Git worktree, treat the path returned by `git rev-parse --show-toplevel` as the only source checkout for the session. Before planning, reviewing, or dispatching a subagent, verify that root and use paths relative to it. Markdown links in agent, skill, and rule files are relative to their source Markdown file; never pass a raw `../` or `../../` link target to a tool from the session directory. If a source path resolves outside the active worktree, stop and report the mismatch instead of reading the parent `nesso` checkout.
+
 ## Area rules
 
 Canonical in `.rules/` — read the full file when relevant:


### PR DESCRIPTION
## Summary

Two-part harness cleanup: tighten per-agent permissions in OpenCode to deny destructive git commands, and add worktree path-safety guidance across agents, rules, and skills.

## Changes

- **Agent permissions:** deny `git commit *`, `git push *`, `rm *` on every agent
- **plan:** scoped edit to `.plans/*` only (was unrestricted allow)
- **brainstorm/fix:** changed from `bash: ask` to `bash: allow` with explicit denies
- **guard-review/quality-review:** added `task: deny` and `git checkout *: deny`
- **build/plan:** added `task: allow` (may dispatch read-only `explore` subagent)
- **AGENTS.md:** added "Worktree and path safety" section
- **.rules/harness.md:** added worktree-rooted tool paths invariant
- **Skills:** fixed relative markdown links to use bare filenames

## Checklist

- [x] Branch name follows the naming convention
- [x] `## [Unreleased]` in `CHANGELOG.md` updated

## Testing

N/A — harness-only changes (OpenCode config files, rules, skills)