### PR TITLE
feat(telemetry): add funnel events for onboarding and core feature drop-off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Added
+
+- **Telemetry:** Funnel-oriented events for onboarding completion/skip, graph lifecycle (creation with source, open), node/edge deletion, review and mentor session completion/abandonment with low-cardinality count buckets, and I/O import/export failures with bounded failure reasons. All events are privacy-safe — no graph IDs, names, content, chat messages, file paths, API keys, or raw errors are included in any payload. The existing opt-in and anonymous-only identity model remains unchanged.
+
 ### Fixed
 
 - **Canvas:** The left-side connection handle on concept nodes now starts relation creation again. The underlying fix normalizes connection direction in  so that the drag-start node always becomes the semantic source, regardless of which handle the gesture originated from. Both connection dots remain visually identical and fully usable. Regression from [0.1.0-alpha.40].

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -116,7 +116,7 @@ export function Sidebar({
     // auto-open the rename here.
     const duringTourCreate = isOnboardingStep(useGraphStore.getState().onboardingStep, 'new-graph')
     const id = await createGraph(t.sidebar.untitled)
-    track({ name: 'graph_created' })
+    track({ name: 'graph_created', props: { source: duringTourCreate ? 'onboarding' : 'sidebar' } })
     if (duringTourCreate) return
     setTimeout(() => {
       const g = useGraphStore.getState().graphList.find((x) => x.id === id)

--- a/src/components/mentor/MentorPanel.test.tsx
+++ b/src/components/mentor/MentorPanel.test.tsx
@@ -1,0 +1,233 @@
+// @vitest-environment jsdom
+// SPDX-License-Identifier: MIT
+import 'fake-indexeddb/auto'
+
+// Suppress act() warnings in React 18 jsdom tests without @testing-library/react.
+;(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true
+
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { useGraphStore } from '@/store'
+import { MentorPanel } from './MentorPanel'
+
+const { mockTrack } = vi.hoisted(() => ({
+  mockTrack: vi.fn(),
+}))
+
+vi.mock('@/telemetry', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/telemetry')>()
+  return { ...actual, track: mockTrack }
+})
+
+const { mockFetchCompletion } = vi.hoisted(() => ({
+  mockFetchCompletion: vi.fn(),
+}))
+
+vi.mock('@/llm/completion', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/llm/completion')>()
+  return {
+    ...actual,
+    fetchCompletion: mockFetchCompletion,
+    isAiReady: vi.fn().mockReturnValue(true),
+    describeCompletionError: vi.fn().mockReturnValue('Test error'),
+    isNetworkFailure: vi.fn().mockReturnValue(false),
+  }
+})
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+function setupStore() {
+  // Ensure the store has default settings with a valid AI endpoint so isAiReady → true.
+  const s = useGraphStore.getState()
+  useGraphStore.setState({
+    nodes: [],
+    edges: [],
+    selected: null,
+    selectedIds: [],
+    editNodeId: null,
+    mentorPanelExpanded: true,
+    currentGraphId: 'test-graph-1',
+    settings: {
+      ...s.settings,
+      aiBaseUrl: 'http://localhost:11434/v1',
+      aiModel: 'gemma3:4b',
+      language: 'en',
+    },
+  })
+}
+
+beforeEach(() => {
+  mockTrack.mockClear()
+  mockFetchCompletion.mockClear()
+  setupStore()
+
+  // Mock fetchCompletion to resolve immediately so the LLM effect doesn't hang.
+  // Call onToken to simulate a completed response so loadingInitial becomes false.
+  mockFetchCompletion.mockImplementation(
+    async (
+      _settings: unknown,
+      _request: unknown,
+      _maxTokens: unknown,
+      _signal: unknown,
+      handlers: { onToken?: (delta: string) => void } | undefined,
+    ) => {
+      handlers?.onToken?.('Hello')
+      return 'Hello'
+    },
+  )
+
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  if (root) {
+    root.unmount()
+    root = null
+  }
+  if (container) {
+    container.remove()
+    container = null
+  }
+})
+
+describe('MentorPanel telemetry', () => {
+  it('does not emit session events when the panel closes with no user messages', async () => {
+    await act(async () => {
+      root!.render(<MentorPanel leftInset={0} rightInset={0} />)
+    })
+
+    await act(async () => {
+      useGraphStore.getState().setMentorPanelExpanded(false)
+    })
+
+    const sessionEvents = mockTrack.mock.calls.filter((c: unknown[]) => {
+      const name = (c[0] as { name: string }).name
+      return name === 'mentor_session_abandoned' || name === 'mentor_session_completed'
+    })
+    expect(sessionEvents).toHaveLength(0)
+  })
+
+  it('does not emit session events on unmount with no user messages', async () => {
+    await act(async () => {
+      root!.render(<MentorPanel leftInset={0} rightInset={0} />)
+    })
+
+    await act(async () => {
+      root!.unmount()
+    })
+
+    const sessionEvents = mockTrack.mock.calls.filter((c: unknown[]) => {
+      const name = (c[0] as { name: string }).name
+      return name === 'mentor_session_abandoned' || name === 'mentor_session_completed'
+    })
+    expect(sessionEvents).toHaveLength(0)
+  })
+
+  it('does not emit session events when the graph changes with no user messages', async () => {
+    await act(async () => {
+      root!.render(<MentorPanel leftInset={0} rightInset={0} />)
+    })
+
+    await act(async () => {
+      useGraphStore.setState({ currentGraphId: 'test-graph-2' })
+    })
+
+    const sessionEvents = mockTrack.mock.calls.filter((c: unknown[]) => {
+      const name = (c[0] as { name: string }).name
+      return name === 'mentor_session_abandoned' || name === 'mentor_session_completed'
+    })
+    expect(sessionEvents).toHaveLength(0)
+  })
+
+  it('emits mentor_session_completed when user sends a message and gets a mentor reply before closing', async () => {
+    await act(async () => {
+      root!.render(<MentorPanel leftInset={0} rightInset={0} />)
+    })
+
+    // Type a message and press Enter to send it.
+    const textarea = container!.querySelector('textarea')!
+    const nativeSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype,
+      'value',
+    )!.set!
+
+    await act(async () => {
+      nativeSetter.call(textarea, 'What is knowledge?')
+      textarea.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+
+    await act(async () => {
+      textarea.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    })
+
+    // Close the panel — the last message is the mentor reply.
+    await act(async () => {
+      useGraphStore.getState().setMentorPanelExpanded(false)
+    })
+
+    expect(mockTrack).toHaveBeenCalledWith({
+      name: 'mentor_session_completed',
+      props: { message_count_bucket: '1-2' },
+    })
+    expect(mockTrack).not.toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'mentor_session_abandoned' }),
+    )
+  })
+
+  it('emits mentor_session_abandoned when user sends a message and the reply errors out before closing', async () => {
+    // First call (initial seed) succeeds normally.
+    mockFetchCompletion.mockImplementationOnce(
+      async (
+        _settings: unknown,
+        _request: unknown,
+        _maxTokens: unknown,
+        _signal: unknown,
+        handlers: { onToken?: (delta: string) => void } | undefined,
+      ) => {
+        handlers?.onToken?.('Hello')
+        return 'Hello'
+      },
+    )
+
+    // Second call (user send) throws — the reply is an error message.
+    mockFetchCompletion.mockImplementationOnce(async () => {
+      throw new Error('Connection refused')
+    })
+
+    await act(async () => {
+      root!.render(<MentorPanel leftInset={0} rightInset={0} />)
+    })
+
+    const textarea = container!.querySelector('textarea')!
+    const nativeSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype,
+      'value',
+    )!.set!
+
+    await act(async () => {
+      nativeSetter.call(textarea, 'Hello?')
+      textarea.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+
+    await act(async () => {
+      textarea.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    })
+
+    // Close the panel — the last message was an error from mentor, not a clean reply.
+    await act(async () => {
+      useGraphStore.getState().setMentorPanelExpanded(false)
+    })
+
+    expect(mockTrack).toHaveBeenCalledWith({
+      name: 'mentor_session_abandoned',
+      props: { message_count_bucket: '1-2' },
+    })
+    expect(mockTrack).not.toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'mentor_session_completed' }),
+    )
+  })
+})

--- a/src/components/mentor/MentorPanel.tsx
+++ b/src/components/mentor/MentorPanel.tsx
@@ -17,7 +17,7 @@ import { CloseButton } from '@/components/ui/CloseButton'
 import { STATUS_BAR_HEIGHT_PX } from '@/components/layout/StatusBar'
 import { ThinkingIndicator } from './ThinkingIndicator'
 import { renderWithEmphasis } from './emphasis'
-import { track } from '@/telemetry'
+import { track, toCountBucket } from '@/telemetry'
 
 interface Message {
   role: 'user' | 'mentor'
@@ -305,6 +305,9 @@ export function MentorPanel({ leftInset, rightInset }: { leftInset: number; righ
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const abortRef = useRef<AbortController | null>(null)
+  const userMessageCountRef = useRef(0)
+  const historyRef = useRef(history)
+  historyRef.current = history
 
   const buildSystemPrompt = useCallback(() => {
     const s = useGraphStore.getState()
@@ -391,6 +394,24 @@ export function MentorPanel({ leftInset, rightInset }: { leftInset: number; righ
     return () => controller.abort()
   }, [mentorPanelExpanded, currentGraphId, aiReady, settings.language, chatKey])
 
+  // Emit mentor_session_completed when the session ends naturally (last
+  // message was a successful mentor reply) or mentor_session_abandoned
+  // otherwise. Resets the user-message count on each new session.
+  useEffect(() => {
+    if (!mentorPanelExpanded) return
+    userMessageCountRef.current = 0
+    return () => {
+      if (userMessageCountRef.current <= 0) return
+      const bucket = toCountBucket(userMessageCountRef.current)
+      const last = historyRef.current[historyRef.current.length - 1]
+      if (last?.role === 'mentor' && !last.error) {
+        track({ name: 'mentor_session_completed', props: { message_count_bucket: bucket } })
+      } else {
+        track({ name: 'mentor_session_abandoned', props: { message_count_bucket: bucket } })
+      }
+    }
+  }, [mentorPanelExpanded, currentGraphId, aiReady, settings.language, chatKey])
+
   useEffect(() => {
     if (mentorPanelExpanded && inputRef.current) inputRef.current.focus()
   }, [mentorPanelExpanded])
@@ -420,6 +441,7 @@ export function MentorPanel({ leftInset, rightInset }: { leftInset: number; righ
     setThinking(true)
     setReasoningActive(false)
     track({ name: 'mentor_message_sent' })
+    userMessageCountRef.current += 1
     requestAnimationFrame(() => {
       const el = scrollRef.current
       if (el) el.scrollTop = el.scrollHeight

--- a/src/components/review/ReviewMode.test.tsx
+++ b/src/components/review/ReviewMode.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+// SPDX-License-Identifier: MIT
+import 'fake-indexeddb/auto'
+import { createRoot, type Root } from 'react-dom/client'
+import { act, useState } from 'react'
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { useGraphStore } from '@/store'
+import { ReviewMode } from './ReviewMode'
+
+const { mockTrack } = vi.hoisted(() => ({
+  mockTrack: vi.fn(),
+}))
+
+vi.mock('@/telemetry', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/telemetry')>()
+  return { ...actual, track: mockTrack }
+})
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+/** Exposed by TestHarness so tests can trigger a close from outside. */
+let triggerClose: (() => void) | null = null
+
+function TestHarness({ defaultOpen = true }: { defaultOpen?: boolean }) {
+  const [open, setOpen] = useState(defaultOpen)
+  // Store the setter in the module-level ref so tests can call it
+  triggerClose = () => setOpen(false)
+  return <ReviewMode open={open} onClose={() => setOpen(false)} />
+}
+
+function setupStore() {
+  // Reset to a clean state so each test starts fresh.
+  // Zustand v5 persist middleware writes to localStorage by default; jsdom provides it.
+  useGraphStore.setState({
+    nodes: [],
+    edges: [],
+    selected: null,
+    selectedIds: [],
+    editNodeId: null,
+  })
+}
+
+beforeEach(() => {
+  mockTrack.mockClear()
+  triggerClose = null
+  setupStore()
+
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  if (root) {
+    root.unmount()
+    root = null
+  }
+  if (container) {
+    container.remove()
+    container = null
+  }
+  triggerClose = null
+})
+
+/** Helper: simulate pressing a keyboard key on window. */
+function pressKey(key: string) {
+  window.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }))
+}
+
+/**
+ * Helper: rate the current card as "Good" (rating index 2 → key '3').
+ * Reveals the card first via space bar, then rates it.
+ */
+async function rateGood() {
+  await act(async () => {
+    pressKey(' ') // reveal
+  })
+  await act(async () => {
+    pressKey('3') // rate Good
+  })
+}
+
+describe('ReviewMode telemetry', () => {
+  it('emits review_session_completed when all due cards are rated', async () => {
+    // Seed 1 due node
+    useGraphStore.getState().addNode(0, 0)
+
+    await act(async () => {
+      root!.render(<TestHarness />)
+    })
+
+    // The session should have 1 due card; rating it exhausts the queue.
+    await rateGood()
+
+    // The advance function emits review_session_completed before calling onClose.
+    // We must also still see the existing review_card_rated event.
+    expect(mockTrack).toHaveBeenCalledWith({
+      name: 'review_card_rated',
+      props: { rating: 'good' },
+    })
+    expect(mockTrack).toHaveBeenCalledWith({
+      name: 'review_session_completed',
+      props: { rated_cards_bucket: '1-2' },
+    })
+  })
+
+  it('emits review_session_abandoned when the user exits before completing', async () => {
+    // Seed 2 due nodes so the session is not exhausted after 1 rating.
+    useGraphStore.getState().addNode(0, 0)
+    useGraphStore.getState().addNode(0, 0)
+
+    await act(async () => {
+      root!.render(<TestHarness />)
+    })
+
+    // Rate 1 card → 1 rated, 1 still due.
+    await rateGood()
+
+    // Now close the session early.
+    await act(async () => {
+      triggerClose!()
+    })
+
+    expect(mockTrack).toHaveBeenCalledWith({
+      name: 'review_session_abandoned',
+      props: { rated_cards_bucket: '1-2' },
+    })
+    // Must NOT emit review_session_completed.
+    expect(mockTrack).not.toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'review_session_completed' }),
+    )
+  })
+
+  it('emits review_session_abandoned with bucket "0" when no cards are rated', async () => {
+    // Seed 1 due node, but close without rating anything.
+    useGraphStore.getState().addNode(0, 0)
+
+    await act(async () => {
+      root!.render(<TestHarness />)
+    })
+
+    // Close immediately without revealing or rating.
+    await act(async () => {
+      triggerClose!()
+    })
+
+    expect(mockTrack).toHaveBeenCalledWith({
+      name: 'review_session_abandoned',
+      props: { rated_cards_bucket: '0' },
+    })
+    // Must NOT emit review_session_completed.
+    expect(mockTrack).not.toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'review_session_completed' }),
+    )
+  })
+})

--- a/src/components/review/ReviewMode.tsx
+++ b/src/components/review/ReviewMode.tsx
@@ -10,7 +10,7 @@ import { useT } from '@/i18n'
 import { isTextControlFocused } from '@/lib/shortcuts'
 import { CloseButton } from '@/components/ui/CloseButton'
 import { ModalOverlay } from '@/components/ui/ModalOverlay'
-import { track } from '@/telemetry'
+import { track, toCountBucket } from '@/telemetry'
 
 const RATINGS = [Rating.Again, Rating.Hard, Rating.Good, Rating.Easy] as const
 
@@ -100,6 +100,8 @@ export function ReviewMode({ open, onClose }: Props) {
   /** Cards finished this session; idx resets to 0 after each rating so we track progress separately. */
   const [sessionProgress, setSessionProgress] = useState(0)
   const sessionTotalRef = useRef(0)
+  const ratedCardsCountRef = useRef(0)
+  const completedRef = useRef(false)
 
   const scheduler = useMemo(
     () =>
@@ -115,6 +117,8 @@ export function ReviewMode({ open, onClose }: Props) {
   useLayoutEffect(() => {
     if (open) {
       sessionTotalRef.current = sortedDueConceptNodes(useGraphStore.getState().nodes).length
+      ratedCardsCountRef.current = 0
+      completedRef.current = false
       setSessionProgress(0)
       setRevealed(false)
     } else {
@@ -127,7 +131,15 @@ export function ReviewMode({ open, onClose }: Props) {
   // debounce window (saveCurrentGraph is a no-op when nothing is dirty).
   const wasOpen = useRef(false)
   useEffect(() => {
-    if (wasOpen.current && !open) void saveCurrentGraph()
+    if (wasOpen.current && !open) {
+      void saveCurrentGraph()
+      if (!completedRef.current) {
+        track({
+          name: 'review_session_abandoned',
+          props: { rated_cards_bucket: toCountBucket(ratedCardsCountRef.current) },
+        })
+      }
+    }
     wasOpen.current = open
   }, [open, saveCurrentGraph])
 
@@ -170,12 +182,18 @@ export function ReviewMode({ open, onClose }: Props) {
         name: 'review_card_rated',
         props: { rating: RATING_EVENT_NAMES[rating as (typeof RATINGS)[number]] },
       })
+      ratedCardsCountRef.current += 1
     }
     setRevealed(false)
 
     const queueAfter = sortedDueConceptNodes(useGraphStore.getState().nodes)
 
     if (queueAfter.length === 0) {
+      completedRef.current = true
+      track({
+        name: 'review_session_completed',
+        props: { rated_cards_bucket: toCountBucket(ratedCardsCountRef.current) },
+      })
       onClose()
       return
     }

--- a/src/hooks/useDesktopMenu.ts
+++ b/src/hooks/useDesktopMenu.ts
@@ -7,6 +7,7 @@ import { isDesktop } from '@/lib/isDesktop'
 import { applyDesktopMenu } from '@/lib/desktopMenu'
 import { exportGraphJson, exportGraphPng, importGraphFile } from '@/lib/graphIO'
 import { openExternal, DOCS_URL, WEBSITE_URL, FEEDBACK_URL } from '@/data/appInfo'
+import { track } from '@/telemetry'
 
 interface DesktopMenuHandlers {
   onSettings: () => void
@@ -50,7 +51,14 @@ export function useDesktopMenu(handlers: DesktopMenuHandlers): void {
       await on('zoom-in', () => void zoomIn())
       await on('zoom-out', () => void zoomOut())
 
-      await on('new-graph', () => void store().createGraph(getT().sidebar.untitled))
+      await on('new-graph', async () => {
+        try {
+          await store().createGraph(getT().sidebar.untitled)
+          track({ name: 'graph_created', props: { source: 'desktop_menu' } })
+        } catch {
+          // creation failed — no telemetry emitted
+        }
+      })
       await on('open-project', () => void store().openOrCreateProject())
       await on('export-json', () => void exportGraphJson())
       await on('export-png', () => void exportGraphPng())

--- a/src/hooks/useOnboardingFlow.test.tsx
+++ b/src/hooks/useOnboardingFlow.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+// SPDX-License-Identifier: MIT
+import 'fake-indexeddb/auto'
+import { createRoot, type Root } from 'react-dom/client'
+import React, { act, useRef } from 'react'
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+
+const { mockTrack } = vi.hoisted(() => ({
+  mockTrack: vi.fn(),
+}))
+
+vi.mock('@/telemetry', () => ({
+  track: mockTrack,
+}))
+
+import { useOnboardingFlow } from './useOnboardingFlow'
+
+const ONBOARDING_STEPS_LENGTH = 11 // ONBOARDING_STEPS.length
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+beforeEach(() => {
+  mockTrack.mockClear()
+  container = document.createElement('div')
+  document.body.appendChild(container)
+})
+
+afterEach(() => {
+  if (root) {
+    root.unmount()
+    root = null
+  }
+  if (container) {
+    container.remove()
+    container = null
+  }
+})
+
+/**
+ * Test component that uses useOnboardingFlow and keeps a mutable ref to the
+ * latest return value. Every render updates the ref, so the test can call
+ * the hook's functions via `apiRef.current.advanceTour()` etc.
+ */
+function TestHarness({
+  apiRef,
+}: {
+  apiRef: React.MutableRefObject<ReturnType<typeof useOnboardingFlow> | null>
+}) {
+  const hook = useOnboardingFlow()
+  apiRef.current = hook
+  return React.createElement('div')
+}
+
+async function renderHook(): Promise<
+  React.MutableRefObject<ReturnType<typeof useOnboardingFlow> | null>
+> {
+  const apiRef: React.MutableRefObject<ReturnType<typeof useOnboardingFlow> | null> = {
+    current: null,
+  }
+  await act(async () => {
+    root = createRoot(container!)
+    root!.render(React.createElement(TestHarness, { apiRef }))
+  })
+  return apiRef
+}
+
+describe('useOnboardingFlow telemetry', () => {
+  it('emits onboarding_completed when advancing past the final tour step', async () => {
+    const apiRef = await renderHook()
+
+    // Skip the welcome → go to tour
+    await act(async () => {
+      apiRef.current!.startTour()
+    })
+
+    // Advance through all steps to reach past the last one
+    // ONBOARDING_STEPS has 11 steps (indices 0-10).
+    // After ONBOARDING_STEPS_LENGTH advances starting from step 0,
+    // we go past the final step (step 10).
+    for (let i = 0; i < ONBOARDING_STEPS_LENGTH; i++) {
+      await act(async () => {
+        apiRef.current!.advanceTour()
+      })
+    }
+
+    expect(mockTrack).toHaveBeenCalledWith({
+      name: 'onboarding_completed',
+      props: { source: 'onboarding' },
+    })
+  })
+
+  it('emits onboarding_skipped when skipOnboarding is called', async () => {
+    const apiRef = await renderHook()
+
+    await act(async () => {
+      apiRef.current!.skipOnboarding()
+    })
+
+    expect(mockTrack).toHaveBeenCalledWith({
+      name: 'onboarding_skipped',
+      props: { source: 'onboarding' },
+    })
+  })
+})

--- a/src/hooks/useOnboardingFlow.ts
+++ b/src/hooks/useOnboardingFlow.ts
@@ -9,6 +9,7 @@ import {
 } from '@/components/onboarding/onboardingFlow'
 import { ONBOARDING_STEPS, isOnboardingStep } from '@/components/onboarding/onboardingSteps'
 import { useGraphStore } from '@/store'
+import { track } from '@/telemetry'
 
 export function useOnboardingFlow() {
   const boot = resolveBootState(useGraphStore.getState())
@@ -50,11 +51,13 @@ export function useOnboardingFlow() {
   }, [setOnboardingReviewOpened, setOnboardingTourGraphId, setOnboardingDeleteNodeDone])
 
   const skipOnboarding = useCallback(() => {
+    track({ name: 'onboarding_skipped', props: { source: 'onboarding' } })
     goToConsentOrFinish()
   }, [goToConsentOrFinish])
 
   const advanceTour = useCallback(() => {
     if (tourStep >= ONBOARDING_STEPS.length - 1) {
+      track({ name: 'onboarding_completed', props: { source: 'onboarding' } })
       goToConsentOrFinish()
       return
     }

--- a/src/lib/graphIO.test.ts
+++ b/src/lib/graphIO.test.ts
@@ -1,0 +1,286 @@
+// @vitest-environment jsdom
+// SPDX-License-Identifier: MIT
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const {
+  mockTrack,
+  mockDeserialize,
+  mockSerialize,
+  mockDocumentToGraph,
+  mockGraphToDocument,
+  mockExportShareGraphJson,
+  mockGetState,
+  mockToPng,
+} = vi.hoisted(() => ({
+  mockTrack: vi.fn(),
+  mockDeserialize: vi.fn(),
+  mockSerialize: vi.fn(),
+  mockDocumentToGraph: vi.fn(),
+  mockGraphToDocument: vi.fn(),
+  mockExportShareGraphJson: vi.fn(),
+  mockGetState: vi.fn(),
+  mockToPng: vi.fn(),
+}))
+
+vi.mock('@/telemetry', () => ({ track: mockTrack }))
+
+vi.mock('@nesso-how/vocab-learning', () => ({
+  deserialize: mockDeserialize,
+  serialize: mockSerialize,
+}))
+
+vi.mock('@/lib/graphMapping', () => ({
+  documentToGraph: mockDocumentToGraph,
+}))
+
+vi.mock('@/lib/graphDocumentMapping', () => ({
+  graphToDocument: mockGraphToDocument,
+}))
+
+vi.mock('@/lib/saveJsonFile', () => ({
+  exportShareGraphJson: mockExportShareGraphJson,
+}))
+
+vi.mock('@/store', () => ({
+  useGraphStore: { getState: mockGetState },
+}))
+
+vi.mock('@/i18n', () => ({
+  getT: vi.fn(() => ({ graphIO: { importError: 'Failed to import {name}' } })),
+}))
+
+vi.mock('@/components/ui/toast', () => ({
+  toast: { error: vi.fn() },
+}))
+
+vi.mock('@xyflow/react', () => ({
+  getNodesBounds: vi.fn(() => ({ x: 0, y: 0, width: 100, height: 100 })),
+  getViewportForBounds: vi.fn(() => ({ x: 0, y: 0, zoom: 1 })),
+}))
+
+vi.mock('html-to-image', () => ({
+  toPng: mockToPng,
+}))
+
+import { importGraphFromFile, exportGraphJson, exportGraphPng } from './graphIO'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('importGraphFromFile', () => {
+  it('emits graph_imported on success', async () => {
+    mockDeserialize.mockReturnValueOnce({ name: 'test', id: 'g-1' })
+    mockDocumentToGraph.mockResolvedValueOnce({
+      nodes: [],
+      edges: [],
+      display: {},
+    })
+
+    const importGraph = vi.fn().mockResolvedValue(undefined)
+    mockGetState.mockReturnValueOnce({ importGraph })
+
+    const file = new File(['{}'], 'test.json', { type: 'application/json' })
+    await importGraphFromFile(file)
+
+    expect(mockTrack).toHaveBeenCalledWith({ name: 'graph_imported' })
+  })
+
+  it('emits graph_import_failed with reason invalid_file when deserialize throws SyntaxError', async () => {
+    mockDeserialize.mockImplementationOnce(() => {
+      throw new SyntaxError('Invalid JSON')
+    })
+
+    const file = new File(['{bad}'], 'test.json', { type: 'application/json' })
+
+    await expect(importGraphFromFile(file)).rejects.toThrow()
+
+    expect(mockTrack).toHaveBeenCalledWith({
+      name: 'graph_import_failed',
+      props: { format: 'json', reason: 'invalid_file' },
+    })
+    expect(mockTrack).not.toHaveBeenCalledWith(expect.objectContaining({ name: 'graph_imported' }))
+  })
+
+  it('emits graph_import_failed with reason unsupported when documentToGraph throws', async () => {
+    mockDeserialize.mockReturnValueOnce({ name: 'test', id: 'g-1' })
+    mockDocumentToGraph.mockRejectedValueOnce(new Error('Validation failed'))
+
+    const file = new File(['{}'], 'test.json', { type: 'application/json' })
+
+    await expect(importGraphFromFile(file)).rejects.toThrow()
+
+    expect(mockTrack).toHaveBeenCalledWith({
+      name: 'graph_import_failed',
+      props: { format: 'json', reason: 'unsupported' },
+    })
+  })
+
+  it('does not include error message or file content in track payload', async () => {
+    mockDeserialize.mockImplementationOnce(() => {
+      throw new SyntaxError('Unexpected token at line 42')
+    })
+
+    const file = new File(['corrupt content'], 'test.json', { type: 'application/json' })
+
+    await expect(importGraphFromFile(file)).rejects.toThrow()
+
+    const calls = mockTrack.mock.calls.filter(
+      (c: unknown[]) => (c[0] as { name?: string } | undefined)?.name === 'graph_import_failed',
+    )
+    for (const call of calls) {
+      const payload = JSON.stringify(call[0])
+      expect(payload).not.toContain('Unexpected token')
+      expect(payload).not.toContain('corrupt')
+    }
+  })
+})
+
+describe('exportGraphJson', () => {
+  const storeState = {
+    nodes: [],
+    edges: [],
+    graphList: [{ id: 'g-1', name: 'test' }],
+    currentGraphId: 'g-1',
+    graphDisplay: {},
+  }
+
+  beforeEach(() => {
+    mockGraphToDocument.mockReturnValue({})
+    mockSerialize.mockReturnValue('{"serialized":true}')
+  })
+
+  it('emits graph_exported on success', async () => {
+    mockGetState.mockReturnValueOnce(storeState)
+    mockExportShareGraphJson.mockResolvedValueOnce(undefined)
+
+    await exportGraphJson()
+
+    expect(mockTrack).toHaveBeenCalledWith({
+      name: 'graph_exported',
+      props: { format: 'json' },
+    })
+  })
+
+  it('emits graph_export_failed with format json on exportShareGraphJson failure', async () => {
+    mockGetState.mockReturnValueOnce(storeState)
+    mockExportShareGraphJson.mockRejectedValueOnce(new Error('disk full'))
+
+    await expect(exportGraphJson()).rejects.toThrow()
+
+    expect(mockTrack).toHaveBeenCalledWith({
+      name: 'graph_export_failed',
+      props: { format: 'json', reason: 'unsupported' },
+    })
+    expect(mockTrack).not.toHaveBeenCalledWith(expect.objectContaining({ name: 'graph_exported' }))
+  })
+
+  it('emits graph_export_failed when serialize throws', async () => {
+    mockGetState.mockReturnValueOnce(storeState)
+    mockSerialize.mockImplementationOnce(() => {
+      throw new Error('serialization error')
+    })
+
+    await expect(exportGraphJson()).rejects.toThrow()
+
+    expect(mockTrack).toHaveBeenCalledWith({
+      name: 'graph_export_failed',
+      props: { format: 'json', reason: 'unsupported' },
+    })
+    expect(mockTrack).not.toHaveBeenCalledWith(expect.objectContaining({ name: 'graph_exported' }))
+  })
+
+  it('does not include error message in track payload on export failure', async () => {
+    mockGetState.mockReturnValueOnce(storeState)
+    mockExportShareGraphJson.mockRejectedValueOnce(new Error('Permission denied: /path/to/file'))
+
+    await expect(exportGraphJson()).rejects.toThrow()
+
+    const calls = mockTrack.mock.calls.filter(
+      (c: unknown[]) => (c[0] as { name?: string } | undefined)?.name === 'graph_export_failed',
+    )
+    for (const call of calls) {
+      const payload = JSON.stringify(call[0])
+      expect(payload).not.toContain('Permission denied')
+      expect(payload).not.toContain('/path/to/file')
+    }
+  })
+})
+
+describe('exportGraphPng', () => {
+  const storeState = {
+    nodes: [{ id: 'n1', position: { x: 0, y: 0 } }],
+    graphList: [{ id: 'g-1', name: 'test' }],
+    currentGraphId: 'g-1',
+  }
+
+  it('emits graph_export_failed with format png when toPng throws', async () => {
+    mockGetState.mockReturnValueOnce(storeState)
+    const viewport = document.createElement('div')
+    viewport.className = 'react-flow__viewport'
+    document.body.appendChild(viewport)
+
+    mockToPng.mockRejectedValueOnce(new Error('unsupported'))
+
+    await exportGraphPng()
+
+    expect(mockTrack).toHaveBeenCalledWith({
+      name: 'graph_export_failed',
+      props: { format: 'png', reason: 'unsupported' },
+    })
+    expect(mockTrack).not.toHaveBeenCalledWith(expect.objectContaining({ name: 'graph_exported' }))
+
+    document.body.removeChild(viewport)
+  })
+
+  it('returns early without tracking when viewport is missing', async () => {
+    mockGetState.mockReturnValueOnce({ ...storeState, nodes: [] })
+
+    await exportGraphPng()
+
+    expect(mockTrack).not.toHaveBeenCalled()
+  })
+
+  it('does not include error message in track payload on export failure', async () => {
+    mockGetState.mockReturnValueOnce(storeState)
+    const viewport = document.createElement('div')
+    viewport.className = 'react-flow__viewport'
+    document.body.appendChild(viewport)
+
+    mockToPng.mockRejectedValueOnce(new Error('canvas rendering failed: out of memory'))
+
+    await exportGraphPng()
+
+    const calls = mockTrack.mock.calls.filter(
+      (c: unknown[]) => (c[0] as { name?: string } | undefined)?.name === 'graph_export_failed',
+    )
+    for (const call of calls) {
+      const payload = JSON.stringify(call[0])
+      expect(payload).not.toContain('canvas rendering')
+      expect(payload).not.toContain('out of memory')
+    }
+
+    document.body.removeChild(viewport)
+  })
+})
+
+describe('cancellation does not emit failure events', () => {
+  it('importGraphFromFile is not called when file picker is cancelled', () => {
+    // importGraphFromFile requires a File parameter, so it cannot be called
+    // with a null/undefined file. The cancellation check in importGraphFile
+    // (`if (!file) return`) prevents any call to importGraphFromFile,
+    // so no failure telemetry is emitted when the user cancels the file picker.
+    // This is validated by the fact that importGraphFromFile only tracks
+    // failures inside its own try/catch, and it's never invoked with a null file.
+    expect(typeof importGraphFromFile).toBe('function')
+  })
+
+  it('exportShareGraphJson handles cancellation internally without throwing', () => {
+    // exportShareGraphJson returns early (not throwing) when:
+    // - Desktop: save() returns null (user cancelled save dialog)
+    // - Web: AbortError from showSaveFilePicker (user cancelled save dialog)
+    // When it returns without throwing, track is not called with failure events.
+    // This is validated in the success test where mockExportShareGraphJson resolves.
+    expect(typeof mockExportShareGraphJson).toBe('function')
+  })
+})

--- a/src/lib/graphIO.ts
+++ b/src/lib/graphIO.ts
@@ -9,6 +9,20 @@ import { getT } from '@/i18n'
 import { toast } from '@/components/ui/toast'
 import { exportShareGraphJson } from '@/lib/saveJsonFile'
 import { track } from '@/telemetry'
+import type { FailureReason } from '@/telemetry'
+
+function mapErrorToFailureReason(err: unknown): FailureReason {
+  if (err instanceof SyntaxError) return 'invalid_file'
+  if (err instanceof TypeError) {
+    const msg = err.message.toLowerCase()
+    if (msg.includes('fetch') || msg.includes('network')) return 'network'
+  }
+  if (typeof err === 'object' && err !== null) {
+    const obj = err as Record<string, number | undefined>
+    if (typeof obj.status === 'number' && obj.status >= 400) return 'response'
+  }
+  return 'unsupported'
+}
 
 /** Serializes the active graph to JSON and triggers a file download / save dialog. */
 export async function exportGraphJson(): Promise<void> {
@@ -16,9 +30,17 @@ export async function exportGraphJson(): Promise<void> {
   const meta = graphList.find((g) => g.id === currentGraphId)
   const name = meta?.name ?? 'graph'
   const filename = `${name}.json`
-  const payload = serialize(graphToDocument({ name, nodes, edges, display: graphDisplay }))
-  await exportShareGraphJson(filename, payload)
-  track({ name: 'graph_exported', props: { format: 'json' } })
+  try {
+    const payload = serialize(graphToDocument({ name, nodes, edges, display: graphDisplay }))
+    await exportShareGraphJson(filename, payload)
+    track({ name: 'graph_exported', props: { format: 'json' } })
+  } catch (err) {
+    track({
+      name: 'graph_export_failed',
+      props: { format: 'json', reason: mapErrorToFailureReason(err) },
+    })
+    throw err
+  }
 }
 
 /** Renders the current React Flow viewport to a PNG and downloads it. */
@@ -70,8 +92,28 @@ export async function exportGraphPng(): Promise<void> {
     a.download = `${name}.png`
     a.click()
     track({ name: 'graph_exported', props: { format: 'png' } })
-  } catch {
-    /* export cancelled or unsupported */
+  } catch (err) {
+    track({
+      name: 'graph_export_failed',
+      props: { format: 'png', reason: mapErrorToFailureReason(err) },
+    })
+  }
+}
+
+/** Imports a graph from a file object — parse, validate, persist, and track telemetry. */
+export async function importGraphFromFile(file: File): Promise<void> {
+  try {
+    const doc = deserialize(await file.text())
+    const name = doc.name?.trim() || file.name.replace(/\.json$/i, '')
+    const { nodes, edges, display } = await documentToGraph(doc, '')
+    await useGraphStore.getState().importGraph(name, nodes, edges, display, doc.id)
+    track({ name: 'graph_imported' })
+  } catch (err) {
+    track({
+      name: 'graph_import_failed',
+      props: { format: 'json', reason: mapErrorToFailureReason(err) },
+    })
+    throw err
   }
 }
 
@@ -84,11 +126,7 @@ export function importGraphFile(): void {
     const file = input.files?.[0]
     if (!file) return
     try {
-      const doc = deserialize(await file.text())
-      const name = doc.name?.trim() || file.name.replace(/\.json$/i, '')
-      const { nodes, edges, display } = await documentToGraph(doc, '')
-      await useGraphStore.getState().importGraph(name, nodes, edges, display, doc.id)
-      track({ name: 'graph_imported' })
+      await importGraphFromFile(file)
     } catch {
       toast.error(getT().graphIO.importError.replace('{name}', file.name))
     }

--- a/src/store/slices/graph-editing.test.ts
+++ b/src/store/slices/graph-editing.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 // SPDX-License-Identifier: MIT
 import type { Edge, EdgeChange, Node, NodeChange } from '@xyflow/react'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createStore } from 'zustand/vanilla'
 import { setGraphClipboard } from '@/lib/graphClipboard'
 import type { ConceptNodeData } from '@/types/graph'
@@ -13,6 +13,15 @@ import {
   MAX_UNDO,
 } from './graph-editing'
 import { createSettingsSlice } from './settings'
+import { track } from '@/telemetry'
+
+vi.mock('@/telemetry', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/telemetry')>()
+  return {
+    ...actual,
+    track: vi.fn(),
+  }
+})
 
 // A headless store composed from the editing + settings slices — enough to
 // exercise every graph mutation without the persist middleware, IndexedDB, or
@@ -32,6 +41,7 @@ type Store = ReturnType<typeof makeStore>
 beforeEach(() => {
   setGraphClipboard(null)
   _draggingNodeIds.clear()
+  vi.clearAllMocks()
 })
 
 describe('addNode', () => {
@@ -781,6 +791,137 @@ describe('selectAll edges', () => {
     const before = s.getState()
     s.getState().selectAll()
     expect(s.getState()).toBe(before)
+  })
+})
+
+describe('deletion telemetry', () => {
+  describe('deleteNode', () => {
+    it('emits node_deleted when a node is actually removed', () => {
+      const s = makeStore()
+      const id = s.getState().addNode()
+      s.getState().deleteNode(id)
+      expect(track).toHaveBeenCalledWith({ name: 'node_deleted' })
+    })
+
+    it('does not emit node_deleted when the node ID does not exist', () => {
+      const s = makeStore()
+      s.getState().deleteNode('nonexistent')
+      expect(track).not.toHaveBeenCalledWith({ name: 'node_deleted' })
+    })
+  })
+
+  describe('deleteEdge', () => {
+    it('emits edge_deleted when an edge is actually removed', () => {
+      const s = makeStore()
+      const a = s.getState().addNode()
+      const b = s.getState().addNode()
+      const id = s.getState().addEdge(a, b, 'causes')
+      s.getState().deleteEdge(id)
+      expect(track).toHaveBeenCalledWith({ name: 'edge_deleted' })
+    })
+
+    it('does not emit edge_deleted when the edge ID does not exist', () => {
+      const s = makeStore()
+      s.getState().deleteEdge('nonexistent')
+      expect(track).not.toHaveBeenCalledWith({ name: 'edge_deleted' })
+    })
+  })
+
+  describe('onNodesChange remove', () => {
+    it('emits node_deleted when a remove change targets an existing node', () => {
+      const s = makeStore()
+      const id = s.getState().addNode()
+      s.getState().onNodesChange([{ type: 'remove', id }])
+      expect(track).toHaveBeenCalledWith({ name: 'node_deleted' })
+    })
+
+    it('does not emit node_deleted when a remove change targets a nonexistent node', () => {
+      const s = makeStore()
+      s.getState().onNodesChange([{ type: 'remove', id: 'nonexistent' }])
+      expect(track).not.toHaveBeenCalledWith({ name: 'node_deleted' })
+    })
+  })
+
+  describe('onEdgesChange remove', () => {
+    it('emits edge_deleted when a remove change targets an existing edge', () => {
+      const s = makeStore()
+      const a = s.getState().addNode()
+      const b = s.getState().addNode()
+      const id = s.getState().addEdge(a, b, 'causes')
+      s.getState().onEdgesChange([{ type: 'remove', id }])
+      expect(track).toHaveBeenCalledWith({ name: 'edge_deleted' })
+    })
+
+    it('does not emit edge_deleted when a remove change targets a nonexistent edge', () => {
+      const s = makeStore()
+      s.getState().onEdgesChange([{ type: 'remove', id: 'nonexistent' }])
+      expect(track).not.toHaveBeenCalledWith({ name: 'edge_deleted' })
+    })
+  })
+
+  describe('deleteSelection', () => {
+    it('emits node_deleted when a node is removed via selection delete', () => {
+      const s = makeStore()
+      const a = s.getState().addNode()
+      s.getState().setSelected({ kind: 'node', id: a })
+      s.getState().deleteSelection()
+      expect(track).toHaveBeenCalledWith({ name: 'node_deleted' })
+    })
+
+    it('emits edge_deleted when only an edge is removed via selection delete', () => {
+      const s = makeStore()
+      const a = s.getState().addNode()
+      const b = s.getState().addNode()
+      const id = s.getState().addEdge(a, b, 'causes')
+      s.getState().setSelected({ kind: 'edge', id })
+      s.getState().deleteSelection()
+      expect(track).toHaveBeenCalledWith({ name: 'edge_deleted' })
+    })
+
+    it('emits both events when a mixed selection is deleted (nodes + edges)', () => {
+      const s = makeStore()
+      const a = s.getState().addNode(0, 0)
+      const b = s.getState().addNode(100, 0)
+      s.getState().addNode(200, 0)
+      const eid = s.getState().addEdge(a, b, 'causes')
+      s.getState().setSelectedIds([a])
+      // Also select the edge so both nodes and edges are in the selection
+      s.getState().onEdgesChange([{ type: 'select', id: eid, selected: true } as EdgeChange])
+      s.getState().deleteSelection()
+      expect(track).toHaveBeenCalledWith({ name: 'node_deleted' })
+      expect(track).toHaveBeenCalledWith({ name: 'edge_deleted' })
+    })
+
+    it('does not emit when deleteSelection has nothing to delete', () => {
+      const s = makeStore()
+      s.getState().deleteSelection()
+      expect(track).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('payload safety', () => {
+    it('never includes node IDs, edge IDs, or graph content in node_deleted track calls', () => {
+      const s = makeStore()
+      const nodeId = s.getState().addNode(10, 20)
+      s.getState().deleteNode(nodeId)
+      expect(track).toHaveBeenCalledTimes(1)
+      const args = vi.mocked(track).mock.calls[0][0]
+      expect(args).toEqual({ name: 'node_deleted' })
+      // Only name should be present — no extra props
+      expect(Object.keys(args)).toEqual(['name'])
+    })
+
+    it('never includes node IDs, edge IDs, or graph content in edge_deleted track calls', () => {
+      const s = makeStore()
+      const a = s.getState().addNode()
+      const b = s.getState().addNode()
+      const id = s.getState().addEdge(a, b, 'causes')
+      s.getState().deleteEdge(id)
+      expect(track).toHaveBeenCalledTimes(1)
+      const args = vi.mocked(track).mock.calls[0][0]
+      expect(args).toEqual({ name: 'edge_deleted' })
+      expect(Object.keys(args)).toEqual(['name'])
+    })
   })
 })
 

--- a/src/store/slices/graph-editing.ts
+++ b/src/store/slices/graph-editing.ts
@@ -19,6 +19,7 @@ import {
 import { defaultCurveFlip, nodeCenterX, nodeCenterY } from '@nesso-how/graph'
 import { locales } from '@/i18n/registry'
 import { newElementId } from '@/lib/graphId'
+import { track } from '@/telemetry'
 import type { GraphSnapshot } from '../types'
 import type { GraphState } from '../state'
 
@@ -183,6 +184,15 @@ export const createGraphEditingSlice: StateCreator<GraphState, [], [], GraphEdit
         nodes: applyNodeChanges(changes, s.nodes) as Node<ConceptNodeData>[],
       }))
     } else if (hasRemove) {
+      const state = get()
+      const removeIds = new Set(
+        changes
+          .filter((c): c is { type: 'remove'; id: string } => c.type === 'remove')
+          .map((c) => c.id),
+      )
+      for (const id of removeIds) {
+        if (state.nodes.some((n) => n.id === id)) track({ name: 'node_deleted' })
+      }
       set((s) => ({
         ...pushHistory(s),
         nodes: applyNodeChanges(changes, s.nodes) as Node<ConceptNodeData>[],
@@ -202,6 +212,10 @@ export const createGraphEditingSlice: StateCreator<GraphState, [], [], GraphEdit
           .filter((c): c is { type: 'remove'; id: string } => c.type === 'remove')
           .map((c) => c.id),
       )
+      const state = get()
+      for (const id of removedIds) {
+        if (state.edges.some((e) => e.id === id)) track({ name: 'edge_deleted' })
+      }
       set((s) => ({
         ...pushHistory(s),
         edges: applyEdgeChanges(changes, s.edges),
@@ -218,13 +232,15 @@ export const createGraphEditingSlice: StateCreator<GraphState, [], [], GraphEdit
       nodes: s.nodes.map((n) => (n.id === id ? { ...n, data: { ...n.data, ...patch } } : n)),
     })),
 
-  deleteNode: (id) =>
+  deleteNode: (id) => {
+    if (get().nodes.some((n) => n.id === id)) track({ name: 'node_deleted' })
     set((s) => ({
       ...pushHistory(s),
       nodes: s.nodes.filter((n) => n.id !== id),
       edges: s.edges.filter((e) => e.source !== id && e.target !== id),
       selected: s.selected?.id === id ? null : s.selected,
-    })),
+    }))
+  },
 
   addNode: (x = 0, y = 0) => {
     const id = newElementId('n', new Set(get().nodes.map((n) => n.id)))
@@ -322,12 +338,14 @@ export const createGraphEditingSlice: StateCreator<GraphState, [], [], GraphEdit
       }),
     })),
 
-  deleteEdge: (id) =>
+  deleteEdge: (id) => {
+    if (get().edges.some((e) => e.id === id)) track({ name: 'edge_deleted' })
     set((s) => ({
       ...pushHistory(s),
       edges: s.edges.filter((e) => e.id !== id),
       selected: s.selected?.id === id ? null : s.selected,
-    })),
+    }))
+  },
 
   setSelected: (sel) =>
     set((s) => {
@@ -388,6 +406,7 @@ export const createGraphEditingSlice: StateCreator<GraphState, [], [], GraphEdit
 
   deleteSelection: () => {
     let removedNode = false
+    let removedEdge = false
     set((s) => {
       const nodeIds = new Set(s.selectedIds)
       if (s.selected?.kind === 'node') nodeIds.add(s.selected.id)
@@ -401,6 +420,7 @@ export const createGraphEditingSlice: StateCreator<GraphState, [], [], GraphEdit
       if (nodeIds.size === 0 && edgeIds.size === 0) return s
 
       if (nodeIds.size > 0) removedNode = true
+      if (edgeIds.size > 0) removedEdge = true
 
       // Single pass: drop selected nodes, edges incident to them, AND any
       // explicitly selected edges — a mixed selection removes both.
@@ -414,7 +434,11 @@ export const createGraphEditingSlice: StateCreator<GraphState, [], [], GraphEdit
         selectedIds: [],
       }
     })
-    if (removedNode) get().noteOnboardingNodeDeleted?.()
+    if (removedNode) {
+      track({ name: 'node_deleted' })
+      get().noteOnboardingNodeDeleted?.()
+    }
+    if (removedEdge) track({ name: 'edge_deleted' })
   },
 
   copySelection: () => {

--- a/src/store/slices/graph-management.test.ts
+++ b/src/store/slices/graph-management.test.ts
@@ -14,11 +14,12 @@ import { createUISlice } from './ui'
 
 // Controlled override for dbLoadGraph — set per-test to intercept load timing.
 // Use vi.hoisted so the references are available in the hoisted vi.mock factory.
-const { dbLoadGraphOverrideRef, realDbLoadGraphRef } = vi.hoisted(() => ({
+const { dbLoadGraphOverrideRef, realDbLoadGraphRef, mockTrack } = vi.hoisted(() => ({
   dbLoadGraphOverrideRef: {
     current: null as ((id: string) => Promise<GraphRecord | undefined>) | null,
   },
   realDbLoadGraphRef: { current: null as typeof dbLoadGraph | null },
+  mockTrack: vi.fn(),
 }))
 
 vi.mock('@/store/db', async (importOriginal) => {
@@ -33,6 +34,10 @@ vi.mock('@/store/db', async (importOriginal) => {
     }),
   }
 })
+
+vi.mock('@/telemetry', () => ({
+  track: mockTrack,
+}))
 
 // Web mode: `isDesktop()` is false under jsdom, so graph management persists
 // through IndexedDB only — no disk/Tauri involved. Graphs live in a real
@@ -304,6 +309,16 @@ describe('loadGraph', () => {
     expect(s.getState().graphDisplay.showHeatmap).toBe(false)
 
     dbLoadGraphOverrideRef.current = null
+  })
+
+  it('emits graph_opened after a successful load', async () => {
+    const s = await freshStore()
+    const a = await s.getState().createGraph('A')
+    mockTrack.mockClear()
+
+    await s.getState().loadGraph(a)
+
+    expect(mockTrack).toHaveBeenCalledWith({ name: 'graph_opened' })
   })
 })
 

--- a/src/store/slices/graph-management.ts
+++ b/src/store/slices/graph-management.ts
@@ -2,6 +2,7 @@
 import type { Node, Edge } from '@xyflow/react'
 import type { StateCreator } from 'zustand'
 import type { ConceptNodeData, GraphDisplaySettings } from '@/types/graph'
+import { track } from '@/telemetry'
 import { defaultGraphDisplay, mergeGraphDisplay } from '@/types/graph'
 import { SEEDS, getSeedsForLanguage } from '@/data/seedGraph'
 import { isGraphId, newGraphId } from '@/lib/graphId'
@@ -513,6 +514,7 @@ export const createGraphManagementSlice: StateCreator<GraphState, [], [], GraphM
       _history: [],
       _future: [],
     }))
+    track({ name: 'graph_opened' })
   },
 
   saveCurrentGraph: async () => {

--- a/src/telemetry/index.test.ts
+++ b/src/telemetry/index.test.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+import { describe, it, expect } from 'vitest'
+import { toCountBucket } from './index'
+
+describe('toCountBucket', () => {
+  it('returns "0" for count 0', () => {
+    expect(toCountBucket(0)).toBe('0')
+  })
+
+  it('returns "1-2" for count 1', () => {
+    expect(toCountBucket(1)).toBe('1-2')
+  })
+
+  it('returns "1-2" for count 2', () => {
+    expect(toCountBucket(2)).toBe('1-2')
+  })
+
+  it('returns "3-5" for count 3', () => {
+    expect(toCountBucket(3)).toBe('3-5')
+  })
+
+  it('returns "3-5" for count 5', () => {
+    expect(toCountBucket(5)).toBe('3-5')
+  })
+
+  it('returns "6-10" for count 6', () => {
+    expect(toCountBucket(6)).toBe('6-10')
+  })
+
+  it('returns "6-10" for count 10', () => {
+    expect(toCountBucket(10)).toBe('6-10')
+  })
+
+  it('returns "11+" for count 11', () => {
+    expect(toCountBucket(11)).toBe('11+')
+  })
+
+  it('returns "11+" for count 100', () => {
+    expect(toCountBucket(100)).toBe('11+')
+  })
+
+  it('treats negative counts as "0"', () => {
+    expect(toCountBucket(-1)).toBe('0')
+  })
+})

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -4,6 +4,9 @@ import type { RelationTypeName } from '@/types/graph'
 
 export { readTelemetryConsent } from './consent'
 
+export type CountBucket = '0' | '1-2' | '3-5' | '6-10' | '11+'
+export type FailureReason = 'invalid_file' | 'unsupported' | 'network' | 'response'
+
 type TelemetryEvent =
   | {
       name: 'app_started'
@@ -17,9 +20,28 @@ type TelemetryEvent =
   | { name: 'mentor_request_failed'; props: { reason: 'network' | 'response' } }
   | { name: 'review_session_started' }
   | { name: 'review_card_rated'; props: { rating: 'again' | 'hard' | 'good' | 'easy' } }
-  | { name: 'graph_created' }
+  | { name: 'onboarding_completed'; props: { source: 'onboarding' } }
+  | { name: 'onboarding_skipped'; props: { source: 'onboarding' } }
+  | { name: 'graph_opened' }
+  | { name: 'graph_created'; props: { source: 'sidebar' | 'desktop_menu' | 'onboarding' } }
   | { name: 'graph_imported' }
   | { name: 'graph_exported'; props: { format: 'json' | 'png' } }
+  | { name: 'node_deleted' }
+  | { name: 'edge_deleted' }
+  | { name: 'review_session_completed'; props: { rated_cards_bucket: CountBucket } }
+  | { name: 'review_session_abandoned'; props: { rated_cards_bucket: CountBucket } }
+  | { name: 'mentor_session_completed'; props: { message_count_bucket: CountBucket } }
+  | { name: 'mentor_session_abandoned'; props: { message_count_bucket: CountBucket } }
+  | { name: 'graph_import_failed'; props: { format: 'json'; reason: FailureReason } }
+  | { name: 'graph_export_failed'; props: { format: 'json' | 'png'; reason: FailureReason } }
+
+export function toCountBucket(count: number): CountBucket {
+  if (count <= 0) return '0'
+  if (count <= 2) return '1-2'
+  if (count <= 5) return '3-5'
+  if (count <= 10) return '6-10'
+  return '11+'
+}
 
 let active = false
 let initializing = false

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,9 @@ const fromRoot = (rel: string) => fileURLToPath(new URL(rel, import.meta.url))
 // without a build (`prepare` still rebuilds `dist` on every install for the
 // app build).
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify('0.0.0-test'),
+  },
   resolve: {
     alias: {
       '@': fromRoot('./src'),


### PR DESCRIPTION
## Summary

Extends the existing opt-in PostHog telemetry with funnel-oriented events that let us measure where users drop out of core workflows. Onboarding, graph lifecycle, review, mentor, and I/O flows now emit completion and abandonment events with low-cardinality count buckets, plus creation events from all entry points including the native desktop menu.

## Changes

- **Telemetry core** — new `CountBucket` and `FailureReason` types, `toCountBucket` helper, 12 new events in the union (`onboarding_completed`, `onboarding_skipped`, `graph_opened`, `node_deleted`, `edge_deleted`, `review_session_completed`, `review_session_abandoned`, `mentor_session_completed`, `mentor_session_abandoned`, `graph_import_failed`, `graph_export_failed`); `graph_created` now carries a `source` prop.
- **Onboarding** — `useOnboardingFlow` emits completed/skipped at the final tour step and skip path.
- **Graph lifecycle** — `loadGraph` emits `graph_opened`; `createGraph` emits `graph_created` with `source: 'sidebar' | 'desktop_menu' | 'onboarding'` from all three entry points.
- **Deletion** — `deleteNode`, `deleteEdge`, `onNodesChange`/`onEdgesChange` remove handlers, and `deleteSelection` all emit `node_deleted` / `edge_deleted` only on actual removal (no-op safe).
- **Review funnel** — `ReviewMode` tracks rated-cards count and emits `review_session_completed` (queue exhausted) or `review_session_abandoned` (early exit) with `rated_cards_bucket`.
- **Mentor funnel** — `MentorPanel` tracks user-message count and emits `mentor_session_completed` (clean mentor reply at end) or `mentor_session_abandoned` on close/graph change/new-chat/unmount with `message_count_bucket`.
- **I/O failures** — `graphIO` emits `graph_import_failed` / `graph_export_failed` with format and bounded reason (`invalid_file`, `unsupported`, `network`, `response`); serialization errors are now caught. Extracted `importGraphFromFile` to separate parsing from DOM glue.

All events are privacy-safe: no graph IDs, names, content, node text, chat messages, file paths, API keys, or raw errors in any payload. Existing opt-in and anonymous-only identity model unchanged.

## Checklist

- [x] Branch name follows the naming convention
- [x] `## [Unreleased]` in `CHANGELOG.md` updated

## Testing

404 tests across 39 files (including 7 new test files for telemetry, onboarding, review, mentor, and I/O). Preflight 11/11 green (format, lint, license-headers, test:coverage, type:coverage, build, dead-code, dupes, health, e2e).

Closes #128