### PR TITLE
feat(mentor): use native desktop HTTP transport

### DIFF
--- a/.opencode/agents/work.md
+++ b/.opencode/agents/work.md
@@ -33,9 +33,13 @@ GitHub Issue → plan (read-only subagent) → work persists plan → [user appr
                                        ↓
                                  create branch
                                        ↓
-                        build (subagent) per task → [TDD green checks pass]
-                                                       ↓
-                                 review (skill) → [verdict]
+                         build (subagent) per task → [TDD green checks pass]
+                                                        ↓
+                                  preflight → [green]
+                                                        ↓
+                    review (skill), unless explicitly skipped
+                                                        ↓
+                                  [verdict / summary]
                                                        ↓
                           summary → [user decides path]
                                  /                    \
@@ -71,11 +75,17 @@ GitHub Issue → plan (read-only subagent) → work persists plan → [user appr
 ### After all build tasks pass
 
 1. Run **`preflight`** to catch mechanical regressions across the full change (not per-task). If anything is red, re-dispatch `build` with the error context and re-run preflight after.
-2. Load the **`review`** skill and follow it — it orchestrates the review subagents (`guard-review` + `quality-review` in parallel) and synthesizes a verdict.
+2. Decide whether the review gate applies:
+   - Review is required for every non-trivial change.
+   - A change is trivial only when it is narrowly scoped to documentation, rules, formatting, or another mechanical edit with no runtime, security, dependency, data, or API behavior impact, and preflight is green.
+   - For a potentially trivial change, explain the criteria and **suggest** that the user may skip review. Do not skip silently; wait for the user's explicit choice.
+   - If the user chooses review, load the **`review`** skill and follow it — it orchestrates `guard-review` and `quality-review` in parallel and synthesizes a verdict.
+   - If the user explicitly chooses to skip review, record that decision in the summary and continue to the publish approval gate. Skipping review never implies approval to commit, push, or open a PR.
+   - If a review has already started, its fix loop remains in force: user-approved review fixes require preflight and another review before publishing.
 
 ### After review — present and ask
 
-3. Present the **review report** to the user: verdict, blocking items (if any), bugs/risks, suggestions. Then **recommend a path** and ask the user which to take:
+3. If review ran, present the **review report** to the user: verdict, blocking items (if any), bugs/risks, suggestions. Then **recommend a path** and ask the user which to take. If review was explicitly skipped for a trivial change, present the verification summary and ask whether to publish or make further changes:
 
    | Review outcome                                         | Recommended path                                     | User says              |
    | ------------------------------------------------------ | ---------------------------------------------------- | ---------------------- |
@@ -86,18 +96,18 @@ GitHub Issue → plan (read-only subagent) → work persists plan → [user appr
 
    The user always decides. The agent recommends; never loop silently.
 
-4. **If the user confirms build directly**: dispatch `build` for each suggested fix, then re-run preflight and re-run review. Do not commit during this fix loop. If the new review still has findings, loop at step 3 again.
+4. **If the user confirms build directly**: dispatch `build` for each suggested fix, then re-run preflight and re-run review. Do not commit during this fix loop. If the new review still has findings, loop at step 3 again. This applies whenever a review has run; a skipped review does not create a silent review loop.
 5. **If ready to PR** and the user explicitly says "ship it" / "go ahead": update `## [Unreleased]` in `CHANGELOG.md` per `.rules/changelog.md`, commit the complete working tree with a concise conventional commit message, then load the **`create-pr`** skill with `--auto` and follow it to push, open the PR, and enable auto-merge. Never commit or push before this approval gate; `create-pr` proceeds without further confirmation.
 
 ## Phase Table
 
-| Phase     | Agent                       | Gate                     |
-| --------- | --------------------------- | ------------------------ |
-| Planning  | `plan` (subagent)           | User approves plan       |
-| Branch    | `work` (direct)             | Branch created from main |
-| Execution | `build` (subagent) per task | TDD green + fast checks  |
-| Review    | `review` (skill)            | No blocking findings     |
-| Publish   | `create-pr` (skill)         | PR opened on GitHub      |
+| Phase     | Agent                                                            | Gate                                                 |
+| --------- | ---------------------------------------------------------------- | ---------------------------------------------------- |
+| Planning  | `plan` (subagent)                                                | User approves plan                                   |
+| Branch    | `work` (direct)                                                  | Branch created from main                             |
+| Execution | `build` (subagent) per task                                      | TDD green + fast checks                              |
+| Review    | `review` (skill, unless explicitly skipped for a trivial change) | No blocking findings, or explicit user-approved skip |
+| Publish   | `create-pr` (skill)                                              | PR opened on GitHub                                  |
 
 ## Session Boundaries
 
@@ -111,14 +121,14 @@ All hard rules live in `AGENTS.md` → **Constraints**. Every subagent is instru
 
 ## Red Flags
 
-| Thought                            | Reality                                                                                         |
-| ---------------------------------- | ----------------------------------------------------------------------------------------------- |
-| "I'll just fix this quickly"       | Never silently patch. After review, present the report and recommend a path — the user decides. |
-| "This doesn't need review"         | Every change needs review.                                                                      |
-| "I'll just commit this"            | No commits without explicit consent.                                                            |
-| "The subagent will handle it"      | You are the gate. Verify before proceeding.                                                     |
-| "This is too simple for planning"  | First plan always: yes. Post-review trivial fixes: ask the user.                                |
-| "Silently loop on review failures" | Always present the report, recommend a path, and let the user decide.                           |
+| Thought                            | Reality                                                                                                                              |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| "I'll just fix this quickly"       | Never silently patch. After review, present the report and recommend a path — the user decides.                                      |
+| "This doesn't need review"         | Review is required by default. For a genuinely trivial change, explain why and ask the user whether to skip it; never skip silently. |
+| "I'll just commit this"            | No commits without explicit consent.                                                                                                 |
+| "The subagent will handle it"      | You are the gate. Verify before proceeding.                                                                                          |
+| "This is too simple for planning"  | First plan always: yes. Post-review trivial fixes: ask the user.                                                                     |
+| "Silently loop on review failures" | Always present the report, recommend a path, and let the user decide.                                                                |
 
 ## Subagent Dispatch
 

--- a/.rules/mentor.md
+++ b/.rules/mentor.md
@@ -1,6 +1,6 @@
 # Mentor (Socrates)
 
-`MentorPanel.tsx` is the AI chat component. The mentor is **experimental** and has a **single transport**: an OpenAI-compatible endpoint driven through the **Vercel AI SDK** (`ai` + `@ai-sdk/openai-compatible`) in `src/llm/completion.ts`. Base URL, model, and optional API key come from `aiBaseUrl`, `aiModel`, `aiApiKey`; there is no environment-variable fallback for the key.
+`MentorPanel.tsx` is the AI chat component. The mentor is **experimental** and uses one OpenAI-compatible protocol through the **Vercel AI SDK** (`ai` + `@ai-sdk/openai-compatible`) in `src/llm/completion.ts`. Browser builds use the SDK's normal global `fetch`. Desktop Tauri builds pass a dynamically loaded `@tauri-apps/plugin-http` fetch implementation to the same provider. Base URL, model, and optional API key come from `aiBaseUrl`, `aiModel`, and `aiApiKey`; there is no environment-variable fallback for the key.
 
 Readiness is `isAiReady(settings)` (truthy `aiBaseUrl` + `aiModel`) in `src/llm/completion.ts`. The mentor UI mounts only when `settings.mentorEnabled` is true (`App.tsx`); when off, **Socrates** is hidden from the status bar and `mentorPanelExpanded` is forced closed. When enabled but not ready, `MentorPanel` shows a short setup hint (`t.mentor.needsSetup`) and disables the input until an endpoint is configured. The default points at a local Ollama instance (`http://localhost:11434/v1`, `gemma3:4b`).
 
@@ -44,11 +44,14 @@ Whether the mentor **sheet** is open is `mentorPanelExpanded` on `useGraphStore`
 
 ## API call
 
-Completions go through **`fetchCompletion()`** in `src/llm/completion.ts`, which calls the SDK's **`streamText`** against a model built by `createOpenAICompatible({ baseURL, apiKey }).chatModel(aiModel)`. It takes a `CompletionRequest` (`{ instructions?, messages }`) as its second argument, plus an optional `AbortSignal` (wired to `streamText`'s `abortSignal`); abort on panel close or graph switch.
+Completions go through **`fetchCompletion()`** in `src/llm/completion.ts`, which calls the SDK's `streamText` against a model built by `createOpenAICompatible({ baseURL, apiKey })`. When `isDesktop()` is true, the provider also receives `fetch: desktopFetch`; that function dynamically imports `@tauri-apps/plugin-http`, forwards the original request and `AbortSignal`, and passes `maxRedirections: 0` so that no redirect chains are followed. Browser builds omit the override and use the normal global fetch. It takes a `CompletionRequest` (`{ instructions?, messages }`) as its second argument, plus an optional `AbortSignal`; abort on panel close or graph switch.
 
-- `model` — `settings.aiModel`; `apiKey` (→ `Authorization: Bearer …`) only when `settings.aiApiKey` is non-empty.
-- `maxOutputTokens` — `MENTOR_MAX_TOKENS` (~2048; a ceiling, not a target — reply length is soft-capped at ~180 words by the prompt, with headroom for reasoning-model thinking)
-- `instructions` — the system prompt (`buildGraphChatPrompt()`), passed to `streamText`'s `instructions` since the SDK rejects `system` roles inside `messages`.
+- `model` — `settings.aiModel`; `apiKey` adds `Authorization: Bearer …` only when `settings.aiApiKey` is non-empty.
+- `maxOutputTokens` — `MENTOR_MAX_TOKENS` (~2048; a ceiling, not a target).
+- `instructions` — the system prompt (`buildGraphChatPrompt()`), passed through `streamText`.
 - `messages` — the `history` turns mapped to `user` / `assistant` roles (`toConversation`).
+- Desktop capability scope — all HTTPS URLs plus loopback HTTP URLs for `localhost`, `127.0.0.1`, and `::1`; arbitrary non-loopback HTTP is not allowed.
+- Desktop transport does not follow redirects — `desktopFetch` passes `maxRedirections: 0`, preserving the configured HTTPS/loopback scope and keeping the bearer key bound to the original endpoint URL.
+- API keys are not logged, included in URLs, or sent anywhere except the configured endpoint's bearer header.
 
-The model is wrapped with **`extractReasoningMiddleware({ tagName: 'think' })`**, so inline `<think>…</think>` (Ollama qwen3, deepseek-r1, …) is split out of the answer. `fetchCompletion` iterates `result.stream` and routes `text-delta` parts to `onToken` and `reasoning-delta` parts to `onReasoning` (an `error` part is rethrown). `isNetworkFailure()` classifies a failure as connection vs HTTP response (`APICallError` without a `statusCode`, or a bare `TypeError`), and `describeCompletionError()` extracts the raw detail (HTTP status + endpoint response body) shown verbatim to the user.
+The model is wrapped with **`extractReasoningMiddleware({ tagName: 'think' })`**, so inline `<think>…</think>` is split out of the answer. `fetchCompletion` iterates `result.stream` and routes `text-delta` parts to `onToken` and `reasoning-delta` parts to `onReasoning`; an `error` part is rethrown. `isNetworkFailure()` and `describeCompletionError()` continue to classify and describe failures without transport-specific branches.

--- a/.rules/static-analysis.md
+++ b/.rules/static-analysis.md
@@ -25,6 +25,8 @@ cargo fmt --all --check --manifest-path src-tauri/Cargo.toml
 cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
 ```
 
+Tauri plugin integrations span `src-tauri/Cargo.toml`, `src-tauri/src/lib.rs`, and `src-tauri/capabilities/default.json`. When adding or changing one, run the four Rust quality gates — `cargo fmt --all --check --manifest-path src-tauri/Cargo.toml`, `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`, `cargo check --manifest-path src-tauri/Cargo.toml --all-targets`, and `cargo test --manifest-path src-tauri/Cargo.toml` — then build the desktop binary so capability URL patterns are validated. Keep native HTTP scopes explicit: HTTPS may be broad for user-configured providers, while HTTP must remain limited to loopback.
+
 ## Type Safety
 
 `tsc -b` (build mode) checks `src/` + all workspace packages:

--- a/.rules/testing.md
+++ b/.rules/testing.md
@@ -52,6 +52,170 @@ The workspace layer (`src/lib/workspace/**`, `src/store/db.ts`) is the most regr
 - **Store IO in web mode** — `isDesktop()` is false under jsdom, so graph-management mutations persist through IndexedDB only and need no fs mock. Seed `loadGraphList()` first so every `graphList` meta has a backing record.
 - **Store IO in desktop mode** — set `window.__TAURI_INTERNALS__ = {}` in `beforeEach` to flip `isDesktop()` true; the store then drives the real workspace layer against the fake fs + fake-indexeddb (disk is the source of truth). See `src/store/slices/graph-management.desktop.test.ts`.
 
+## Mentor transport (`src/llm/completion.ts`)
+
+The mentor's network transport (`fetchCompletion`) lives in `src/llm/completion.ts` and is tested against a **fully stubbed transport layer** — no real HTTP calls ever leave Vitest. The transport has exactly two paths (`isDesktop()` → Tauri `@tauri-apps/plugin-http` vs browser global `fetch`); each transport test pins that the right one fires with the right shape.
+
+### Desktop/browser mode switch
+
+`isDesktop()` reads `window.__TAURI_INTERNALS__`, so the test stub controls which path runs:
+
+```ts
+// Browser mode (isDesktop() → false)
+vi.stubGlobal('window', {})
+
+// Desktop mode (isDesktop() → true)
+vi.stubGlobal('window', { __TAURI_INTERNALS__: {} })
+```
+
+Use `vi.stubGlobal` (not `vi.mock`) so the real `isDesktop()` module runs against the stubbed `window`. Restore in `afterEach` with `vi.unstubAllGlobals()`.
+
+### Browser fetch stub
+
+For the browser path, stub the global `fetch` with a mock that returns a SSE `Response`:
+
+```ts
+vi.stubGlobal('fetch', vi.fn().mockResolvedValue(sseResponse(['Hel', 'lo'])))
+```
+
+Assert that browser `fetch` was called and the Tauri mock was not:
+
+```ts
+expect(browserFetch).toHaveBeenCalledTimes(1)
+expect(mockNativeFetch).not.toHaveBeenCalled()
+```
+
+### Tauri `@tauri-apps/plugin-http` mock
+
+Mock at module resolution (top-level `vi.mock`) so every test sees the same mock instance:
+
+```ts
+const { mockNativeFetch } = vi.hoisted(() => ({
+  mockNativeFetch: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/plugin-http', () => ({
+  fetch: mockNativeFetch,
+}))
+```
+
+`vi.hoisted` hoists the mock reference above the mock factory so both resolve to the same identity. The real `completion.ts` uses a dynamic `import('@tauri-apps/plugin-http')`, but `vi.mock` intercepts static and dynamic imports alike. Reset in `afterEach` with `mockNativeFetch.mockReset()`.
+
+### SSE response fixture
+
+The completion stream is standard OpenAI-compatible SSE. Build mock responses with two helpers:
+
+```ts
+function chunk(content: string): string {
+  return `data: ${JSON.stringify({
+    id: '1',
+    object: 'chat.completion.chunk',
+    choices: [{ index: 0, delta: { content } }],
+  })}\n\n`
+}
+
+function sseResponse(contents: string[]): Response {
+  const encoder = new TextEncoder()
+  const stop = `data: ${JSON.stringify({
+    id: '1',
+    object: 'chat.completion.chunk',
+    choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+  })}\n\n`
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const c of contents) controller.enqueue(encoder.encode(chunk(c)))
+      controller.enqueue(encoder.encode(stop))
+      controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+      controller.close()
+    },
+  })
+  return new Response(stream, {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream' },
+  })
+}
+```
+
+The mock response type is `text/event-stream`, and the stream ends with the standard `data: [DONE]` sentinel.
+
+### Request shape assertions
+
+On the desktop path, assert against the mock's call arguments to verify the transport layer shapes every request correctly — these assertions catch regressions in URL construction, auth plumbing, body shape, and stream flag:
+
+**URL and method.** The SDK appends `/chat/completions` to the base URL; assert the full URL is correct and the method is `POST`:
+
+```ts
+const [url, init] = mockNativeFetch.mock.calls[0] as [string, RequestInit]
+expect(url).toBe('https://opencode.ai/zen/v1/chat/completions')
+expect(init.method).toBe('POST')
+```
+
+**Bearer auth.** The API key (when non-empty) appears only in the `Authorization` header, never in the URL or body:
+
+```ts
+expect(new Headers(init.headers).get('authorization')).toBe('Bearer test-key')
+expect(url).not.toContain('test-key')
+expect(String(init.body)).not.toContain('test-key')
+```
+
+**Request body.** The body encodes model, max output tokens, streaming mode, and messages (system prompt as a `system`-role message). Assert with `toMatchObject` so future SDK-injected fields don't break the test:
+
+```ts
+const body = JSON.parse(String(init.body)) as {
+  model: string
+  messages: { role: string; content: string }[]
+  max_tokens: number
+  stream: boolean
+}
+expect(body).toMatchObject({
+  model: 'big-pickle',
+  max_tokens: 321,
+  stream: true,
+  messages: [
+    { role: 'system', content: 'You are Socrates.' },
+    { role: 'user', content: 'hi' },
+  ],
+})
+```
+
+### AbortSignal passthrough
+
+The `AbortSignal` passed to `fetchCompletion` must reach the underlying `fetch` as the **exact same object**, not a clone or wrapper. Create an `AbortController`, pass its signal, and assert referential identity:
+
+```ts
+const controller = new AbortController()
+// ... call fetchCompletion(..., controller.signal, ...)
+const [, init] = mockNativeFetch.mock.calls[0] as [string, RequestInit]
+expect(init.signal).toBe(controller.signal)
+```
+
+For an abort-while-streaming test: gate the mock stream's `pull` on a manually-released promise, call `controller.abort()` after the first token, then release the gate and assert no late tokens arrived:
+
+```ts
+// Before abort
+expect(tokens).toEqual(['Hel'])
+controller.abort()
+releaseGate()
+await resultPromise.catch(() => {})
+// After abort — no late tokens
+expect(tokens).toEqual(['Hel'])
+```
+
+### No real network in Vitest
+
+The combination of `vi.mock('@tauri-apps/plugin-http')` + `vi.stubGlobal('fetch')` guarantees zero outbound HTTP calls. Every transport test asserts that exactly one transport fired and the other stayed silent. The `afterEach` block resets both (`mockNativeFetch.mockReset()` + `vi.restoreAllMocks()` + `vi.unstubAllGlobals()`) so no state leaks between tests.
+
+### Native/manual verification boundary
+
+Vitest proves the **transport wiring** — which fetch fires, what URL/method/body/auth/signal it receives, and how stream tokens surface. It does **not** prove:
+
+- Actual HTTPS/TLS handshake correctness (cert validation, ALPN)
+- Tauri's native HTTP stack (`reqwest` under `@tauri-apps/plugin-http`)
+- Real SSE parsing from a live endpoint with real network latency
+- Rate limiting, redirects, or HTTP/2 multiplexing
+
+Those belong to the **native e2e lane** (`e2e-native/`, tauri-driver) or manual verification against a real Ollama / OpenAI-compatible endpoint. `completion.ts` is excluded from Stryker mutation testing for the same reason — the transport itself is a thin glue layer, and the real behaviour lives in the SDK and the native HTTP stack (`@ai-sdk/openai-compatible` + `@tauri-apps/plugin-http`), which Stryker cannot meaningfully mutate.
+
 ## CI
 
 `pnpm test:coverage` runs as a required step in `.github/workflows/ci.yml`, gating PRs alongside the checks described in [static-analysis](static-analysis.md). Package `dist` is in place because the prior `pnpm install --frozen-lockfile` step runs `prepare`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 - **ConceptElaboration:** Reduced from six fields (`definition`, `examples`, `notes`, `imageUrl`, `imageTitle`, `imageDescriptionUrl`) to just `definition` — a breaking alpha-only simplification ahead of Writing Mode. All UI (Inspector, Review Mode), serialization, validation, LLM context, MCP schema, seeds, docs, and tests updated accordingly. Old graph files with extended elaboration fields are unsupported.
 
+- **Desktop:** Mentor requests now use Tauri's native HTTP transport, which reaches hosted HTTPS OpenAI-compatible endpoints and loopback Ollama without browser CORS restrictions; the browser transport is unchanged.
+
 ## [0.1.0-alpha.40] - 2026-07-16
 
 ### Added

--- a/docs/src/content/docs/docs/guides/ai-mentor.md
+++ b/docs/src/content/docs/docs/guides/ai-mentor.md
@@ -21,13 +21,17 @@ Chat history is **not persisted**. It lives only for the current panel session.
 
 Configure any OpenAI-compatible `chat/completions` endpoint under **Settings → AI**: base URL, model, and an optional API key. Endpoint fields appear only while the mentor toggle is on.
 
-The default targets a local [Ollama](https://ollama.com/) instance (`http://localhost:11434/v1`, model `gemma3:4b`). Install Ollama, pull a model, and the mentor works with nothing leaving your machine. Any hosted OpenAI-compatible endpoint works too. Set the API key it expects.
+The desktop app uses Tauri's native HTTP client for mentor requests. It supports any `https://` endpoint, including hosted providers such as OpenCode Zen at `https://opencode.ai/zen/v1` with model `big-pickle`. It also supports loopback HTTP endpoints at `localhost`, `127.0.0.1`, and `::1` for local Ollama. Arbitrary non-loopback `http://` endpoints are not permitted by the desktop capability.
+
+The browser app keeps using the browser's normal `fetch`. Hosted endpoints must allow the app's origin, and browser requests to local Ollama still need the Ollama CORS setting described below. Nesso sends an optional API key as `Authorization: Bearer …` only to the configured endpoint and does not log it.
+
+The default targets a local [Ollama](https://ollama.com/) instance (`http://localhost:11434/v1`, model `gemma3:4b`). Install Ollama, pull a model, and the mentor works with nothing leaving your machine. Set the API key expected by a hosted endpoint when one is required.
 
 Until a reachable endpoint is configured, the chat input stays disabled and the mentor shows a short setup hint. If the mentor stops responding once a turn fails, see [Troubleshooting](../../troubleshooting/#mentor-not-responding).
 
 ### Reaching local Ollama from the hosted app
 
-If you use the hosted web app over HTTPS, requests to `http://localhost:11434` are allowed (localhost is exempt from mixed-content blocking), but Ollama still rejects the cross-origin request unless you allow the app's origin: start it with `OLLAMA_ORIGINS=https://app.nesso.how` (or run the desktop build, where this does not apply).
+If you use the hosted web app over HTTPS, requests to `http://localhost:11434` are allowed by the browser, but Ollama still rejects the cross-origin request unless you allow the app's origin. Start it with `OLLAMA_ORIGINS=https://app.nesso.how` or use the desktop build, whose native transport does not require this browser CORS setting.
 
 ## The Socratic persona
 

--- a/docs/src/content/docs/docs/troubleshooting.md
+++ b/docs/src/content/docs/docs/troubleshooting.md
@@ -31,8 +31,10 @@ You can dismiss the available/error states for the rest of the session with the 
 
 If a mentor message fails, the reply bubble shows one of two messages, depending on what went wrong:
 
-- **Can't reach the AI endpoint. Check Settings (`⌘,`) → AI. For local Ollama, run `ollama serve`.** A network-level failure: the endpoint is unreachable, the wrong port, or (on the hosted web app) a CORS rejection from a local Ollama instance. Confirm the base URL in **Settings → AI**, that Ollama (or your server) is actually running, and, if you're on the hosted web app talking to local Ollama, that you started it with `OLLAMA_ORIGINS` set to the app's origin (see [AI mentor](../guides/ai-mentor/#reaching-local-ollama-from-the-hosted-app)).
-- **_Hmm._ My voice failed me. Try again, slowly.** The endpoint was reachable but returned an error or a response Nesso couldn't parse (a model name that doesn't exist, a malformed response, a server-side error). Check the model name and that the endpoint actually speaks the OpenAI-compatible `chat/completions` format.
+- **Can't reach the AI endpoint. Check Settings (`⌘,`) → AI. For local Ollama, run `ollama serve`.** A network-level failure: the endpoint is unreachable, the wrong port, or, on the hosted web app, a CORS rejection from a local Ollama instance. Confirm the base URL in **Settings → AI**, that Ollama or your server is actually running, and, if you're on the hosted web app talking to local Ollama, that you started it with `OLLAMA_ORIGINS` set to the app's origin (see [AI mentor](../guides/ai-mentor/#reaching-local-ollama-from-the-hosted-app)).
+- **_Hmm._ My voice failed me. Try again, slowly.** The endpoint was reachable but returned an error or a response Nesso couldn't parse. Check the model name and that the endpoint speaks the OpenAI-compatible `chat/completions` format.
+
+Desktop mentor requests use the native HTTP client. The desktop capability allows HTTPS and loopback HTTP only. If a desktop endpoint uses non-loopback `http://`, switch it to `https://` or configure a local service on `localhost`, `127.0.0.1`, or `::1`. Browser requests continue to follow normal browser CORS rules.
 
 Closing the mentor panel, switching graphs, or clicking **New chat** aborts any in-flight request without showing an error.
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-fs": "^2.5.0",
+    "@tauri-apps/plugin-http": "^2.5.9",
     "@tauri-apps/plugin-opener": "^2.5.4",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@tauri-apps/plugin-fs':
         specifier: ^2.5.0
         version: 2.5.1
+      '@tauri-apps/plugin-http':
+        specifier: ^2.5.9
+        version: 2.5.9
       '@tauri-apps/plugin-opener':
         specifier: ^2.5.4
         version: 2.5.4
@@ -2080,6 +2083,9 @@ packages:
 
   '@tauri-apps/plugin-fs@2.5.1':
     resolution: {integrity: sha512-9Lz+Jopp6QyeEWhlpkMx4R/+P9HgR+AVAI4vOZhlT8Xaymtz8iVI/Ov984/XTqgJz/5gz5NretqPB/XEMS3NhQ==}
+
+  '@tauri-apps/plugin-http@2.5.9':
+    resolution: {integrity: sha512-lCiY0+vs4HvIUSvZrBs8TC3TiCB0MOPRmiUjTq4prW7SlcJE2jdLeT6KBsJrT9Tlplufl7W1pY6SFAO3gCWxDA==}
 
   '@tauri-apps/plugin-opener@2.5.4':
     resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
@@ -7107,6 +7113,10 @@ snapshots:
       '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-fs@2.5.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
+  '@tauri-apps/plugin-http@2.5.9':
     dependencies:
       '@tauri-apps/api': 2.11.0
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -579,6 +579,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,8 +626,37 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
+ "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -642,7 +682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -655,7 +695,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -664,6 +704,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -780,6 +829,12 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "dbus"
@@ -912,6 +967,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "dom_query"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,6 +1060,15 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "endi"
@@ -1420,8 +1493,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1443,10 +1518,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1598,6 +1676,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,6 +1801,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1727,6 +1825,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1747,9 +1846,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2248,6 +2349,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2264,6 +2371,12 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 dependencies = [
  "value-bag",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "markup5ever"
@@ -2391,6 +2504,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
+ "tauri-plugin-http",
  "tauri-plugin-log",
  "tauri-plugin-mcp-bridge",
  "tauri-plugin-opener",
@@ -3302,6 +3416,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3322,6 +3442,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3334,6 +3464,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.2",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3385,6 +3571,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3420,6 +3617,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3504,6 +3716,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "cookie",
+ "cookie_store",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3689,6 +3944,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3698,7 +3954,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni 0.22.4",
  "log",
@@ -3735,6 +3991,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3824,7 +4086,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3965,6 +4227,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4033,7 +4307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4044,7 +4318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4258,6 +4532,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4278,7 +4573,7 @@ checksum = "a33f7f9e486ade65fcf1e45c440f9236c904f5c1002cdc7fc6ae582777345ce4"
 dependencies = [
  "bitflags 2.11.1",
  "block2 0.6.2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dbus",
@@ -4374,7 +4669,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4518,6 +4813,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-http"
+version = "2.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5bd512048e1985b7ec78f96d99083e2ddaf7e0d906b2b63c44ce5bb8b894067"
+dependencies = [
+ "bytes",
+ "cookie_store",
+ "data-url",
+ "http",
+ "regex",
+ "reqwest 0.12.28",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+ "urlpattern",
+]
+
+[[package]]
 name = "tauri-plugin-log"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4616,7 +4935,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.13.3",
  "rustls",
  "semver",
  "serde",
@@ -5495,6 +5814,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5555,6 +5884,15 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5742,6 +6080,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ log = "0.4"
 tauri = { version = "2.11.0", features = [] }
 tauri-plugin-log = "2"
 tauri-plugin-fs = { version = "2", features = ["watch"] }
+tauri-plugin-http = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-mcp-bridge = "0.11"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,19 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    {
+      "identifier": "http:default",
+      "allow": [
+        { "url": "https://*:*/*" },
+        { "url": "https://*" },
+        { "url": "http://localhost:*/*" },
+        { "url": "http://localhost" },
+        { "url": "http://127.0.0.1:*/*" },
+        { "url": "http://127.0.0.1" },
+        { "url": "http://[::1]:*/*" },
+        { "url": "http://[::1]" }
+      ]
+    },
     "dialog:default",
     "fs:default",
     "fs:allow-appdata-read-recursive",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -327,6 +327,7 @@ fn grant_fs_scope(app: tauri::AppHandle, path: String) -> Result<(), String> {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())

--- a/src/llm/completion.test.ts
+++ b/src/llm/completion.test.ts
@@ -1,6 +1,15 @@
 // SPDX-License-Identifier: MIT
-import { APICallError } from 'ai'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { mockNativeFetch } = vi.hoisted(() => ({
+  mockNativeFetch: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/plugin-http', () => ({
+  fetch: mockNativeFetch,
+}))
+
+import { APICallError } from 'ai'
 import type { NessoSettings } from '@/types/graph'
 import { describeCompletionError, fetchCompletion, isAiReady, isNetworkFailure } from './completion'
 
@@ -9,6 +18,13 @@ const settings = {
   aiModel: 'gemma3:4b',
   aiApiKey: '',
 } as unknown as NessoSettings
+
+const zenSettings = {
+  ...settings,
+  aiBaseUrl: 'https://opencode.ai/zen/v1',
+  aiModel: 'big-pickle',
+  aiApiKey: 'test-key',
+} as NessoSettings
 
 /** One OpenAI-compatible SSE chunk carrying a content delta. */
 function chunk(content: string): string {
@@ -40,7 +56,11 @@ function sseResponse(contents: string[]): Response {
   })
 }
 
-afterEach(() => vi.restoreAllMocks())
+afterEach(() => {
+  mockNativeFetch.mockReset()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
 
 describe('isAiReady', () => {
   it('requires both a base URL and a model', () => {
@@ -109,7 +129,9 @@ describe('describeCompletionError', () => {
 
 describe('fetchCompletion streaming', () => {
   it('forwards answer tokens and returns their concatenation, with a system prompt', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(sseResponse(['Hel', 'lo'])))
+    vi.stubGlobal('window', {})
+    const browserFetch = vi.fn().mockResolvedValue(sseResponse(['Hel', 'lo']))
+    vi.stubGlobal('fetch', browserFetch)
 
     const tokens: string[] = []
     const full = await fetchCompletion(
@@ -122,6 +144,8 @@ describe('fetchCompletion streaming', () => {
 
     expect(tokens.join('')).toBe('Hello')
     expect(full).toBe('Hello')
+    expect(browserFetch).toHaveBeenCalledTimes(1)
+    expect(mockNativeFetch).not.toHaveBeenCalled()
   })
 
   it('splits inline <think> reasoning out of the answer', async () => {
@@ -146,5 +170,147 @@ describe('fetchCompletion streaming', () => {
     expect(full.trim()).toBe('Hello')
     expect(answer.join('')).not.toContain('<think>')
     expect(reasoning.join('')).toContain('because')
+  })
+
+  it('uses Tauri fetch on desktop and preserves the request, bearer key, stream, and signal', async () => {
+    const controller = new AbortController()
+    const browserFetch = vi.fn()
+    vi.stubGlobal('window', { __TAURI_INTERNALS__: {} })
+    vi.stubGlobal('fetch', browserFetch)
+    mockNativeFetch.mockResolvedValue(sseResponse(['Hello']))
+
+    const full = await fetchCompletion(
+      zenSettings,
+      {
+        instructions: 'You are Socrates.',
+        messages: [{ role: 'user', content: 'hi' }],
+      },
+      321,
+      controller.signal,
+    )
+
+    expect(full).toBe('Hello')
+    expect(browserFetch).not.toHaveBeenCalled()
+    expect(mockNativeFetch).toHaveBeenCalledTimes(1)
+
+    const [url, init] = mockNativeFetch.mock.calls[0] as [
+      string,
+      RequestInit & { maxRedirections?: number },
+    ]
+    expect(url).toBe('https://opencode.ai/zen/v1/chat/completions')
+    expect(init.method).toBe('POST')
+    expect(init.maxRedirections).toBe(0)
+    expect(new Headers(init.headers).get('authorization')).toBe('Bearer test-key')
+    expect(init.signal).toBe(controller.signal)
+
+    const body = JSON.parse(String(init.body)) as {
+      model: string
+      messages: { role: string; content: string }[]
+      max_tokens: number
+      stream: boolean
+    }
+
+    expect(body).toMatchObject({
+      model: 'big-pickle',
+      max_tokens: 321,
+      stream: true,
+      messages: [
+        { role: 'system', content: 'You are Socrates.' },
+        { role: 'user', content: 'hi' },
+      ],
+    })
+    expect(url).not.toContain('test-key')
+    expect(String(init.body)).not.toContain('test-key')
+  })
+
+  it('aborts a pending desktop stream, receives the signal, and delivers no late tokens', async () => {
+    vi.stubGlobal('window', { __TAURI_INTERNALS__: {} })
+    const browserFetch = vi.fn()
+    vi.stubGlobal('fetch', browserFetch)
+
+    const controller = new AbortController()
+    const tokens: string[] = []
+
+    let onFirstToken!: () => void
+    const firstTokenDelivered = new Promise<void>((resolve) => {
+      onFirstToken = resolve
+    })
+
+    // Gate that keeps the stream pending after the first chunk.
+    // The test releases it after abort; the pull handler reads the
+    // signal's aborted flag to decide whether to deliver late tokens.
+    let releaseGate!: () => void
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve
+    })
+
+    const encoder = new TextEncoder()
+    const stopChunk = `data: ${JSON.stringify({
+      id: '1',
+      object: 'chat.completion.chunk',
+      choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+    })}\n\n`
+
+    mockNativeFetch.mockImplementation(async (_input, init) => {
+      const sig = init?.signal as AbortSignal | undefined
+      const stream = new ReadableStream<Uint8Array>({
+        start(ctrl) {
+          ctrl.enqueue(encoder.encode(chunk('Hel')))
+        },
+        async pull(ctrl) {
+          await gate
+          if (sig?.aborted) {
+            ctrl.close()
+            return
+          }
+          // Should only reach here if the signal was NOT properly
+          // passed through or the abort did not propagate – the
+          // late-token assertion below will catch it.
+          ctrl.enqueue(encoder.encode(chunk('lo')))
+          ctrl.enqueue(encoder.encode(stopChunk))
+          ctrl.enqueue(encoder.encode('data: [DONE]\n\n'))
+          ctrl.close()
+        },
+      })
+      return new Response(stream, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      })
+    })
+
+    const resultPromise = fetchCompletion(
+      zenSettings,
+      { instructions: 'You are Socrates.', messages: [{ role: 'user', content: 'hi' }] },
+      100,
+      controller.signal,
+      {
+        onToken: (delta) => {
+          tokens.push(delta)
+          onFirstToken()
+        },
+      },
+    )
+
+    await firstTokenDelivered
+    expect(tokens).toEqual(['Hel'])
+
+    controller.abort()
+
+    // Unblock pull so it can observe the aborted signal and close.
+    releaseGate()
+
+    // Wait for the completion to settle (resolve or reject).
+    await resultPromise.catch(() => {})
+
+    // Signal must be the exact same object passed to the underlying fetch.
+    expect(mockNativeFetch).toHaveBeenCalledTimes(1)
+    const [, init] = mockNativeFetch.mock.calls[0] as [string, RequestInit]
+    expect(init.signal).toBe(controller.signal)
+
+    // No late tokens after abort — 'lo' was never emitted.
+    expect(tokens).toEqual(['Hel'])
+
+    // Browser fetch must not be called on desktop.
+    expect(browserFetch).not.toHaveBeenCalled()
   })
 })

--- a/src/llm/completion.ts
+++ b/src/llm/completion.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
 import { APICallError, extractReasoningMiddleware, streamText, wrapLanguageModel } from 'ai'
+import { isDesktop } from '@/lib/isDesktop'
 import type { NessoSettings } from '@/types/graph'
 
 /** A chat turn. The system prompt is passed separately as `instructions`, never as a role here. */
@@ -22,6 +23,11 @@ export function isAiReady(settings: NessoSettings): boolean {
   return Boolean(settings.aiBaseUrl && settings.aiModel)
 }
 
+const desktopFetch: typeof globalThis.fetch = async (input, init) => {
+  const { fetch } = await import('@tauri-apps/plugin-http')
+  return fetch(input, { ...init, maxRedirections: 0 })
+}
+
 /**
  * Wraps the configured OpenAI-compatible endpoint with reasoning extraction so
  * inline `<think>…</think>` (Ollama qwen3, deepseek-r1, …) is split out of the
@@ -32,6 +38,7 @@ function mentorModel(settings: NessoSettings) {
     name: 'nesso-mentor',
     baseURL: settings.aiBaseUrl.replace(/\/+$/, ''),
     ...(settings.aiApiKey ? { apiKey: settings.aiApiKey } : {}),
+    ...(isDesktop() ? { fetch: desktopFetch } : {}),
   })
   return wrapLanguageModel({
     model: provider.chatModel(settings.aiModel),


### PR DESCRIPTION
## Summary
Adds Tauri native HTTP transport for desktop mentor requests so OpenAI-compatible HTTPS providers and loopback Ollama endpoints work without browser CORS restrictions. Browser transport remains unchanged.

Closes #125

## Changes
- Add and register the Tauri HTTP plugin with HTTPS and loopback-only HTTP capability scopes.
- Dynamically inject native fetch on desktop, disable redirects, and preserve streaming, bearer authentication, and AbortSignal cancellation.
- Add browser/native request-contract and active-abort coverage.
- Update mentor rules, testing/static-analysis guidance, AI mentor docs, troubleshooting docs, and the MCP documentation bundle.
- Make the work agent offer an explicit review skip for genuinely trivial changes.

## Checklist
- [x] Branch name follows the naming convention
- [x] `## [Unreleased]` in `CHANGELOG.md` updated

## Testing
- `pnpm test src/llm/completion.test.ts`
- `pnpm run fast-check`
- `pnpm run preflight -- --rust` — 16/16 checks passed
- MCP documentation bundle rebuilt and verified
