### PR TITLE
fix(mentor): repair desktop AI transport and IPv6 scope

### DIFF
--- a/.rules/static-analysis.md
+++ b/.rules/static-analysis.md
@@ -25,7 +25,7 @@ cargo fmt --all --check --manifest-path src-tauri/Cargo.toml
 cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
 ```
 
-Tauri plugin integrations span `src-tauri/Cargo.toml`, `src-tauri/src/lib.rs`, and `src-tauri/capabilities/default.json`. When adding or changing one, run the four Rust quality gates — `cargo fmt --all --check --manifest-path src-tauri/Cargo.toml`, `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`, `cargo check --manifest-path src-tauri/Cargo.toml --all-targets`, and `cargo test --manifest-path src-tauri/Cargo.toml` — then build the desktop binary so capability URL patterns are validated. Keep native HTTP scopes explicit: HTTPS may be broad for user-configured providers, while HTTP must remain limited to loopback.
+Tauri plugin integrations span `src-tauri/Cargo.toml`, `src-tauri/src/lib.rs`, and `src-tauri/capabilities/default.json`. When adding or changing one, run the four Rust quality gates — `cargo fmt --all --check --manifest-path src-tauri/Cargo.toml`, `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`, `cargo check --manifest-path src-tauri/Cargo.toml --all-targets`, and `cargo test --manifest-path src-tauri/Cargo.toml` — then build the desktop binary as a packaging/integration smoke check. The desktop build does not semantically deserialize plugin-specific capability URL patterns, so keep those patterns covered by a focused native Rust test. Keep native HTTP scopes explicit: HTTPS may be broad for user-configured providers, while HTTP must remain limited to loopback.
 
 ## Type Safety
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Fixed
 
+- **Desktop AI:** Fixed native mentor requests failing when the HTTP capability scope contained unescaped IPv6 loopback patterns. Settings endpoint checks and local Ollama model pulls now share the native/browser transport boundary, preserve authentication, and discard stale results.
+
 - **Canvas:** The left-side connection handle on concept nodes now starts relation creation again. The underlying fix normalizes connection direction in  so that the drag-start node always becomes the semantic source, regardless of which handle the gesture originated from. Both connection dots remain visually identical and fully usable. Regression from [0.1.0-alpha.40].
 
 

--- a/docs/src/content/docs/docs/guides/ai-mentor.md
+++ b/docs/src/content/docs/docs/guides/ai-mentor.md
@@ -29,6 +29,29 @@ The default targets a local [Ollama](https://ollama.com/) instance (`http://loca
 
 Until a reachable endpoint is configured, the chat input stays disabled and the mentor shows a short setup hint. If the mentor stops responding once a turn fails, see [Troubleshooting](../../troubleshooting/#mentor-not-responding).
 
+### Endpoint status
+
+While the AI tab is open in **Settings**, Nesso calls the `/models` endpoint of your configured base URL and shows the result inline:
+
+| Status                | Meaning                                                                                            |
+| --------------------- | -------------------------------------------------------------------------------------------------- |
+| **Checking…**         | Nesso is querying `/models` — shows a spinner until the first response arrives.                    |
+| **Available**         | The model is present in the endpoint's model list. The mentor can start.                           |
+| **Not found locally** | The endpoint is reachable but the model is not installed. On localhost, a **Pull** button appears. |
+| **Pulling `NN`%**     | A native Ollama pull is in progress for the current model (local endpoints only).                  |
+| **Unauthorized**      | The endpoint returned HTTP `401` or `403` — wrong or missing API key.                              |
+| **API unreachable**   | The endpoint did not respond (wrong URL, server down, or network failure).                         |
+
+The status resets to idle when the dialog closes or the mentor toggle is turned off. Changing the base URL, model, or API key triggers a fresh check and cancels any in-flight pull.
+
+### Pulling a model from Ollama
+
+When the endpoint is a `localhost`-based Ollama instance and the model is **Not found locally**, click **Pull** to download it. Progress is streamed in real time, and the status switches to **Available** on success. If the pull fails mid-way, the status shows **API unreachable**.
+
+Pulls are local-only: the pull button appears only for loopback URLs (`localhost`, `127.0.0.1`, `::1`) because it calls the Ollama-native `/api/pull` endpoint. For hosted providers, pull models through their own tools or dashboard.
+
+Closing the **Settings** dialog, disabling the **Mentor** toggle, or changing the model while a pull is running aborts it immediately.
+
 ### Reaching local Ollama from the hosted app
 
 If you use the hosted web app over HTTPS, requests to `http://localhost:11434` are allowed by the browser, but Ollama still rejects the cross-origin request unless you allow the app's origin. Start it with `OLLAMA_ORIGINS=https://app.nesso.how` or use the desktop build, whose native transport does not require this browser CORS setting.

--- a/docs/src/content/docs/docs/troubleshooting.md
+++ b/docs/src/content/docs/docs/troubleshooting.md
@@ -41,3 +41,15 @@ Closing the mentor panel, switching graphs, or clicking **New chat** aborts any 
 ## "No AI endpoint configured"
 
 This isn't a failure: it's the mentor's resting state until you've set up an endpoint. It appears whenever **Mentor** is enabled in **Settings → AI** but the base URL or model field is empty. The input stays disabled until both are filled in. See [AI mentor](../guides/ai-mentor/#connecting-a-model) for setup.
+
+## Model pull stalls or shows stale results
+
+Model pulling is available only for local Ollama endpoints. When you click **Pull** in **Settings → AI**, Nesso streams the download progress from Ollama's `/api/pull` endpoint.
+
+If a pull appears stuck:
+
+- **Changing settings cancels the pull.** Switching the model, base URL, or API key, disabling the mentor toggle, or closing the **Settings** dialog all abort the in-flight pull so stale progress cannot interfere with a new model selection.
+- **Ollama must be reachable on the native port.** Nesso strips the `/v1` suffix from your base URL to reach Ollama's native `/api/pull` endpoint. If you configured a non-standard port, make sure Ollama's native API is running on that same port.
+- **Progress is purely cosmetic.** The pull runs to completion regardless of whether the progress bar is visible. If the pull completes while you are on a different settings tab, the status badge updates when you return to the AI tab.
+
+If the status shows **Unauthorized**, check your API key. The endpoint rejected the request with HTTP `401` or `403`. For hosted providers, make sure the key is valid and has not expired. Local Ollama instances do not require an API key — leave the field empty.

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -14,8 +14,8 @@
         { "url": "http://localhost" },
         { "url": "http://127.0.0.1:*/*" },
         { "url": "http://127.0.0.1" },
-        { "url": "http://[::1]:*/*" },
-        { "url": "http://[::1]" }
+        { "url": "http://[\\:\\:1]:*/*" },
+        { "url": "http://[\\:\\:1]" }
       ]
     },
     "dialog:default",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -373,3 +373,99 @@ pub fn run() {
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }
+
+#[cfg(test)]
+mod http_capability_tests {
+    use serde::Deserialize;
+    use tauri::{
+        utils::acl::{
+            capability::{CapabilityFile, PermissionEntry},
+            RemoteUrlPattern,
+        },
+        Url,
+    };
+
+    #[derive(Deserialize)]
+    struct HttpAllowEntry {
+        url: String,
+    }
+
+    fn http_scope_patterns() -> Vec<RemoteUrlPattern> {
+        let capability: CapabilityFile =
+            serde_json::from_str(include_str!("../capabilities/default.json"))
+                .expect("default capability must deserialize");
+
+        let capability = match capability {
+            CapabilityFile::Capability(capability) => capability,
+            CapabilityFile::List(_) | CapabilityFile::NamedList { .. } => {
+                panic!("default capability must be a single capability")
+            }
+        };
+
+        let allow = capability
+            .permissions
+            .into_iter()
+            .find_map(|permission| match permission {
+                PermissionEntry::ExtendedPermission { identifier, scope }
+                    if identifier.get() == "http:default" =>
+                {
+                    scope.allow
+                }
+                _ => None,
+            })
+            .expect("default capability must define an http:default allow scope");
+
+        allow
+            .into_iter()
+            .map(|value| {
+                let entry: HttpAllowEntry = serde_json::from_value(
+                    serde_json::to_value(value).expect("HTTP scope value must serialize"),
+                )
+                .expect("HTTP allow entry must contain a url string");
+                let raw_pattern = entry.url;
+
+                raw_pattern
+                    .parse::<RemoteUrlPattern>()
+                    .unwrap_or_else(|error| {
+                        panic!("invalid HTTP URL pattern `{raw_pattern}`: {error}")
+                    })
+            })
+            .collect()
+    }
+
+    fn scope_allows(patterns: &[RemoteUrlPattern], raw_url: &str) -> bool {
+        let url = raw_url.parse::<Url>().expect("test URL must be valid");
+        patterns.iter().any(|pattern| pattern.test(&url))
+    }
+
+    #[test]
+    fn default_http_scope_deserializes_and_matches_supported_endpoints() {
+        let patterns = http_scope_patterns();
+
+        for raw_url in [
+            "https://opencode.ai/zen/v1/chat/completions",
+            "https://api.openai.com/v1/chat/completions",
+            "http://localhost:11434/v1/chat/completions",
+            "http://localhost/v1/chat/completions",
+            "http://127.0.0.1:11434/v1/chat/completions",
+            "http://127.0.0.1/v1/chat/completions",
+            "http://[::1]:11434/v1/chat/completions",
+            "http://[::1]/v1/chat/completions",
+        ] {
+            assert!(
+                scope_allows(&patterns, raw_url),
+                "expected {raw_url} to be allowed"
+            );
+        }
+
+        for raw_url in [
+            "http://example.com/v1/chat/completions",
+            "http://192.168.1.10:11434/v1/chat/completions",
+        ] {
+            assert!(
+                !scope_allows(&patterns, raw_url),
+                "expected {raw_url} to be denied"
+            );
+        }
+    }
+}

--- a/src/components/dialogs/SettingsDialog.tsx
+++ b/src/components/dialogs/SettingsDialog.tsx
@@ -13,7 +13,8 @@ import { useT } from '@/i18n'
 import { LearningSettings } from './LearningSettings'
 import { SettingsHeatmapDefault } from '@/components/ui/HeatmapDisplayToggle'
 import type { Language } from '@/types/graph'
-import { checkOllamaModel, streamOllamaModelPull, type OllamaModelStatus } from '@/lib/ollama'
+import { checkEndpoint, executeModelPull } from '@/llm/completion'
+import type { OllamaModelStatus } from '@/lib/ollama'
 
 const OLLAMA_PRESETS = [
   { id: 'llama3.2:3b', note: 'lightweight · fast' },
@@ -42,36 +43,53 @@ export function SettingsDialog({ open, onClose }: Props) {
   const [modelStatus, setModelStatus] = useState<OllamaModelStatus>('idle')
   const [pullProgress, setPullProgress] = useState(0)
 
-  const triggerCheck = useCallback((baseUrl: string, model: string) => {
+  const healthCheckAbortRef = useRef<AbortController | null>(null)
+
+  const triggerCheck = useCallback((baseUrl: string, model: string, apiKey?: string) => {
     if (!model) {
       setModelStatus('idle')
       return
     }
+    healthCheckAbortRef.current?.abort()
+    const controller = new AbortController()
+    healthCheckAbortRef.current = controller
     setModelStatus('checking')
-    checkOllamaModel(baseUrl, model)
-      .then((s) => setModelStatus(s))
-      .catch(() => setModelStatus('error'))
+    checkEndpoint(baseUrl, model, apiKey ?? '', controller.signal)
+      .then((s) => {
+        if (!controller.signal.aborted) setModelStatus(s)
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) setModelStatus('error')
+      })
   }, [])
 
   const pullAbortRef = useRef<AbortController | null>(null)
+  /** Monotonic counter — bumped on each new pull or settings invalidation. */
+  const pullRequestIdRef = useRef(0)
 
   const handlePull = useCallback(async () => {
     pullAbortRef.current?.abort()
+    pullRequestIdRef.current += 1
+    const requestId = pullRequestIdRef.current
+
     const controller = new AbortController()
     pullAbortRef.current = controller
     setModelStatus('pulling')
     setPullProgress(0)
-    try {
-      for await (const p of streamOllamaModelPull(
-        settings.aiBaseUrl,
-        settings.aiModel,
-        controller.signal,
-      )) {
-        setPullProgress(p)
-      }
-      setModelStatus('available')
-    } catch {
-      if (!controller.signal.aborted) setModelStatus('error')
+
+    const guardedProgress = (fraction: number) => {
+      if (pullRequestIdRef.current === requestId) setPullProgress(fraction)
+    }
+
+    const ok = await executeModelPull(
+      settings.aiBaseUrl,
+      settings.aiModel,
+      controller.signal,
+      guardedProgress,
+    )
+    // Only update state if this is still the latest pull request AND not aborted.
+    if (!controller.signal.aborted && pullRequestIdRef.current === requestId) {
+      setModelStatus(ok ? 'available' : 'error')
     }
   }, [settings.aiBaseUrl, settings.aiModel])
 
@@ -82,22 +100,34 @@ export function SettingsDialog({ open, onClose }: Props) {
 
   useEffect(() => {
     if (!open || !settings.mentorEnabled) {
+      healthCheckAbortRef.current?.abort()
+      pullAbortRef.current?.abort()
+      pullRequestIdRef.current = 0
       setModelStatus('idle')
       return
     }
-    let cancelled = false
+    // Settings changed while dialog is open and mentor is enabled — abort
+    // any in-flight pull and invalidate stale requests so an old pull cannot
+    // mark a freshly-selected model as available.
+    pullAbortRef.current?.abort()
+    pullRequestIdRef.current = 0
+
+    const controller = new AbortController()
+    // Abort any in-flight check from the previous effect invocation.
+    healthCheckAbortRef.current?.abort()
+    healthCheckAbortRef.current = controller
     setModelStatus('checking')
-    checkOllamaModel(settings.aiBaseUrl, settings.aiModel)
+    checkEndpoint(settings.aiBaseUrl, settings.aiModel, settings.aiApiKey, controller.signal)
       .then((s) => {
-        if (!cancelled) setModelStatus(s)
+        if (!controller.signal.aborted) setModelStatus(s)
       })
       .catch(() => {
-        if (!cancelled) setModelStatus('error')
+        if (!controller.signal.aborted) setModelStatus('error')
       })
     return () => {
-      cancelled = true
+      controller.abort()
     }
-  }, [open, settings.aiBaseUrl, settings.mentorEnabled])
+  }, [open, settings.aiBaseUrl, settings.aiModel, settings.aiApiKey, settings.mentorEnabled])
 
   const inputStyle: React.CSSProperties = {
     width: '100%',
@@ -423,7 +453,7 @@ export function SettingsDialog({ open, onClose }: Props) {
                                 title={p.note}
                                 onClick={() => {
                                   setSetting('aiModel', p.id)
-                                  triggerCheck(settings.aiBaseUrl, p.id)
+                                  triggerCheck(settings.aiBaseUrl, p.id, settings.aiApiKey)
                                 }}
                                 style={{
                                   appearance: 'none',
@@ -451,7 +481,9 @@ export function SettingsDialog({ open, onClose }: Props) {
                             setSetting('aiModel', e.target.value)
                             setModelStatus('idle')
                           }}
-                          onBlur={(e) => triggerCheck(settings.aiBaseUrl, e.target.value)}
+                          onBlur={(e) =>
+                            triggerCheck(settings.aiBaseUrl, e.target.value, settings.aiApiKey)
+                          }
                           style={inputStyle}
                         />
                         <ModelStatusBadge

--- a/src/components/mentor/ModelStatusBadge.test.tsx
+++ b/src/components/mentor/ModelStatusBadge.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+// SPDX-License-Identifier: MIT
+
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { OllamaModelStatus } from '@/lib/ollama'
+
+// Minimal i18n stub — avoids the persisted store.
+vi.mock('@/i18n', () => ({
+  useT: () => ({
+    settings: {
+      ai: {
+        pulling: (model: string, pct: number) => `Pulling ${model}… ${pct}%`,
+        status: {
+          checking: 'Checking…',
+          available: 'Available',
+          notFound: 'Not found locally',
+          pull: 'Pull',
+          ollamaNotRunning: 'Ollama not running:',
+          corsBlocked: 'CORS blocked. Set',
+          unauthorized: 'Unauthorized',
+          unreachable: 'API unreachable',
+        },
+      },
+    },
+  }),
+}))
+
+import { ModelStatusBadge } from './ModelStatusBadge'
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  if (root) {
+    root.unmount()
+    root = null
+  }
+  if (container) {
+    container.remove()
+    container = null
+  }
+})
+
+function render(
+  status: OllamaModelStatus,
+  baseUrl = 'http://localhost:11434',
+  model = 'gemma3:4b',
+) {
+  act(() => {
+    root!.render(
+      <ModelStatusBadge
+        status={status}
+        model={model}
+        baseUrl={baseUrl}
+        pullProgress={0}
+        onPull={() => {}}
+      />,
+    )
+  })
+}
+
+function textContent(): string {
+  return container!.textContent ?? ''
+}
+
+describe('ModelStatusBadge', () => {
+  it('renders nothing when idle', () => {
+    render('idle')
+    expect(textContent()).toBe('')
+  })
+
+  it('renders nothing when model is empty', () => {
+    render('checking', 'http://localhost:11434', '')
+    expect(textContent()).toBe('')
+  })
+
+  it('shows "Checking…" when checking', () => {
+    render('checking')
+    expect(textContent()).toContain('Checking')
+  })
+
+  it('shows "Available" when available', () => {
+    render('available')
+    expect(textContent()).toContain('Available')
+  })
+
+  it('shows "Not found locally" and a pull button when unavailable on localhost', () => {
+    render('unavailable')
+    expect(textContent()).toContain('Not found locally')
+    expect(textContent()).toContain('Pull')
+  })
+
+  it('does not show pull button for non-local endpoints on unavailable', () => {
+    render('unavailable', 'https://opencode.ai/zen/v1')
+    expect(textContent()).not.toContain('Pull')
+  })
+
+  it('shows pull progress when pulling', () => {
+    act(() => {
+      root!.render(
+        <ModelStatusBadge
+          status="pulling"
+          model="gemma3:4b"
+          baseUrl="http://localhost:11434"
+          pullProgress={0.42}
+          onPull={() => {}}
+        />,
+      )
+    })
+    expect(textContent()).toContain('Pulling')
+    expect(textContent()).toContain('42%')
+  })
+
+  it('shows "Unauthorized" when status is unauthorized', () => {
+    render('unauthorized' as OllamaModelStatus, 'https://opencode.ai/zen/v1')
+    expect(textContent()).toContain('Unauthorized')
+  })
+
+  it('shows "API unreachable" for error on non-local endpoints', () => {
+    render('error', 'https://opencode.ai/zen/v1')
+    expect(textContent()).toContain('API unreachable')
+  })
+})

--- a/src/components/mentor/ModelStatusBadge.tsx
+++ b/src/components/mentor/ModelStatusBadge.tsx
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 import { useT } from '@/i18n'
+import { isDesktop } from '@/lib/isDesktop'
 import type { OllamaModelStatus } from '@/lib/ollama'
+import { isLocalhostUrl } from '@/lib/ollama'
+import { getErrorHint } from './modelStatusDisplay'
 
 interface Props {
   status: OllamaModelStatus
@@ -62,6 +65,8 @@ export function ModelStatusBadge({ status, model, baseUrl, pullProgress, onPull 
     )
   }
 
+  const isLocal = isLocalhostUrl(baseUrl)
+
   return (
     <div
       style={{
@@ -100,37 +105,60 @@ export function ModelStatusBadge({ status, model, baseUrl, pullProgress, onPull 
         <>
           {dot('var(--conf-2)')}
           <span style={{ color: 'var(--ink-3)' }}>{t.settings.ai.status.notFound}</span>
-          <button
-            type="button"
-            onClick={onPull}
-            style={{
-              appearance: 'none',
-              border: '0.5px solid var(--accent)',
-              background: 'transparent',
-              color: 'var(--accent)',
-              fontSize: '11px',
-              fontWeight: 500,
-              fontFamily: 'var(--font-mono)',
-              padding: '2px 8px',
-              borderRadius: 'var(--radius-sm)',
-              cursor: 'pointer',
-            }}
-          >
-            {t.settings.ai.status.pull}
-          </button>
+          {isLocal && (
+            <button
+              type="button"
+              onClick={onPull}
+              style={{
+                appearance: 'none',
+                border: '0.5px solid var(--accent)',
+                background: 'transparent',
+                color: 'var(--accent)',
+                fontSize: '11px',
+                fontWeight: 500,
+                fontFamily: 'var(--font-mono)',
+                padding: '2px 8px',
+                borderRadius: 'var(--radius-sm)',
+                cursor: 'pointer',
+              }}
+            >
+              {t.settings.ai.status.pull}
+            </button>
+          )}
+        </>
+      )}
+      {status === 'unauthorized' && (
+        <>
+          {dot('var(--conf-2)')}
+          <span style={{ color: 'var(--ink-4)' }}>{t.settings.ai.status.unauthorized}</span>
         </>
       )}
       {status === 'error' &&
-        (/localhost|127\.0\.0\.1/.test(baseUrl) ? (
-          /localhost|127\.0\.0\.1/.test(window.location.hostname) ? (
-            <>
-              {dot('var(--ink-4)')}
-              <span style={{ color: 'var(--ink-4)' }}>{t.settings.ai.status.ollamaNotRunning}</span>
-              <code style={{ color: 'var(--ink-2)', fontSize: 'var(--text-xs)' }}>
-                ollama serve
-              </code>
-            </>
-          ) : (
+        (() => {
+          const hint = getErrorHint(baseUrl, isDesktop(), window.location.hostname)
+          if (hint === 'unreachable') {
+            return (
+              <>
+                {dot('var(--ink-4)')}
+                <span style={{ color: 'var(--ink-4)' }}>{t.settings.ai.status.unreachable}</span>
+              </>
+            )
+          }
+          if (hint === 'ollama-not-running') {
+            return (
+              <>
+                {dot('var(--ink-4)')}
+                <span style={{ color: 'var(--ink-4)' }}>
+                  {t.settings.ai.status.ollamaNotRunning}
+                </span>
+                <code style={{ color: 'var(--ink-2)', fontSize: 'var(--text-xs)' }}>
+                  ollama serve
+                </code>
+              </>
+            )
+          }
+          // cors-blocked
+          return (
             <>
               {dot('var(--conf-2)')}
               <span style={{ color: 'var(--ink-4)' }}>{t.settings.ai.status.corsBlocked}</span>
@@ -139,12 +167,7 @@ export function ModelStatusBadge({ status, model, baseUrl, pullProgress, onPull 
               </code>
             </>
           )
-        ) : (
-          <>
-            {dot('var(--ink-4)')}
-            <span style={{ color: 'var(--ink-4)' }}>{t.settings.ai.status.unreachable}</span>
-          </>
-        ))}
+        })()}
     </div>
   )
 }

--- a/src/components/mentor/modelStatusDisplay.test.ts
+++ b/src/components/mentor/modelStatusDisplay.test.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+import { describe, expect, it } from 'vitest'
+import { getErrorHint } from './modelStatusDisplay'
+
+describe('getErrorHint', () => {
+  it('returns unreachable for non-local URLs', () => {
+    expect(getErrorHint('https://opencode.ai/zen/v1', false, 'localhost')).toBe('unreachable')
+    expect(getErrorHint('https://api.openai.com/v1', true, 'localhost')).toBe('unreachable')
+  })
+
+  it('returns ollama-not-running on desktop for any local URL', () => {
+    // Desktop: never CORS — native HTTP transport.
+    expect(getErrorHint('http://localhost:11434/v1', true, 'localhost')).toBe('ollama-not-running')
+    expect(getErrorHint('http://localhost:11434/v1', true, 'app.nesso.how')).toBe(
+      'ollama-not-running',
+    )
+    expect(getErrorHint('http://127.0.0.1:11434/v1', true, 'app.nesso.how')).toBe(
+      'ollama-not-running',
+    )
+    expect(getErrorHint('http://[::1]:11434/v1', true, 'app.nesso.how')).toBe('ollama-not-running')
+  })
+
+  it('returns ollama-not-running on browser when app and endpoint are on the same loopback', () => {
+    expect(getErrorHint('http://localhost:11434/v1', false, 'localhost')).toBe('ollama-not-running')
+    expect(getErrorHint('http://127.0.0.1:11434/v1', false, '127.0.0.1')).toBe('ollama-not-running')
+    expect(getErrorHint('http://127.0.0.1:11434', false, 'localhost')).toBe('ollama-not-running')
+  })
+
+  it('returns cors-blocked on browser when app and endpoint differ', () => {
+    // Browser served from https://app.nesso.how, pointing at local Ollama.
+    expect(getErrorHint('http://localhost:11434/v1', false, 'app.nesso.how')).toBe('cors-blocked')
+    expect(getErrorHint('http://127.0.0.1:11434', false, 'app.nesso.how')).toBe('cors-blocked')
+    expect(getErrorHint('http://[::1]:11434/v1', false, 'nesso.local')).toBe('cors-blocked')
+  })
+
+  it('handles invalid base URLs gracefully by falling back to cors-blocked on browser', () => {
+    // Unparseable local URL on browser — treat as CORS blocked.
+    expect(getErrorHint('not-a-url', false, 'app.nesso.how')).toBe('unreachable')
+  })
+})

--- a/src/components/mentor/modelStatusDisplay.ts
+++ b/src/components/mentor/modelStatusDisplay.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+import { isLocalhostUrl } from '@/llm/completion'
+
+const LOOPBACK_HOST_RE = /^(localhost|127\.0\.0\.1|\[::1\]|::1)$/
+
+export type ErrorHint = 'ollama-not-running' | 'cors-blocked' | 'unreachable'
+
+/**
+ * Classifies an `'error'` status into a display hint based on the endpoint URL,
+ * platform, and the app's own hostname. Pure — no rendering, no store, no fetch.
+ */
+export function getErrorHint(baseUrl: string, isDesktop: boolean, appHostname: string): ErrorHint {
+  if (!isLocalhostUrl(baseUrl)) return 'unreachable'
+  // Desktop: native HTTP transport — never a browser CORS issue.
+  if (isDesktop) return 'ollama-not-running'
+  // Browser: check whether the app is served from the same loopback host.
+  try {
+    const hostname = new URL(baseUrl).hostname
+    if (LOOPBACK_HOST_RE.test(hostname) && LOOPBACK_HOST_RE.test(appHostname)) {
+      return 'ollama-not-running'
+    }
+  } catch {
+    // Unparseable URL — default to CORS hint (local URL we can't parse).
+  }
+  return 'cors-blocked'
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -68,6 +68,7 @@ const en = {
         pull: 'Pull',
         ollamaNotRunning: 'Ollama not running:',
         corsBlocked: 'CORS blocked. Set',
+        unauthorized: 'Unauthorized',
         unreachable: 'API unreachable',
       },
     },

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -68,6 +68,7 @@ const it: typeof en = {
         pull: 'Scarica',
         ollamaNotRunning: 'Ollama non in esecuzione:',
         corsBlocked: 'CORS bloccato. Imposta',
+        unauthorized: 'Non autorizzato',
         unreachable: 'API non raggiungibile',
       },
     },

--- a/src/lib/ollama.test.ts
+++ b/src/lib/ollama.test.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+import { describe, expect, it } from 'vitest'
+import type { OllamaModelStatus } from './ollama'
+import { ollamaNativeBase, isLocalhostUrl } from './ollama'
+
+describe('ollamaNativeBase', () => {
+  it('strips trailing slashes', () => {
+    expect(ollamaNativeBase('http://localhost:11434/v1/')).toBe('http://localhost:11434')
+    expect(ollamaNativeBase('http://localhost:11434/')).toBe('http://localhost:11434')
+  })
+
+  it('strips /v1 suffix and trailing slashes together', () => {
+    expect(ollamaNativeBase('http://localhost:11434/v1')).toBe('http://localhost:11434')
+  })
+
+  it('keeps the URL unchanged if there is no /v1 suffix', () => {
+    expect(ollamaNativeBase('http://localhost:11434')).toBe('http://localhost:11434')
+  })
+
+  it('strips only the final /v1, not an embedded one', () => {
+    expect(ollamaNativeBase('http://localhost:11434/some/v1/path/v1')).toBe(
+      'http://localhost:11434/some/v1/path',
+    )
+  })
+})
+
+// re-export smoke test — full coverage lives in src/llm/completion.test.ts
+describe('isLocalhostUrl (re-export)', () => {
+  it('recognizes localhost as local', () => {
+    expect(isLocalhostUrl('http://localhost:11434/v1')).toBe(true)
+  })
+
+  it('rejects a non-local URL', () => {
+    expect(isLocalhostUrl('https://opencode.ai/zen/v1')).toBe(false)
+  })
+})

--- a/src/lib/ollama.ts
+++ b/src/lib/ollama.ts
@@ -1,68 +1,13 @@
 // SPDX-License-Identifier: MIT
+
 export type OllamaModelStatus =
   | 'idle'
   | 'checking'
   | 'available'
   | 'unavailable'
   | 'pulling'
+  | 'unauthorized'
   | 'error'
 
-export function ollamaNativeBase(aiBaseUrl: string): string {
-  return aiBaseUrl.replace(/\/+$/, '').replace(/\/v1$/, '')
-}
-
-export async function checkOllamaModel(
-  baseUrl: string,
-  model: string,
-): Promise<'available' | 'unavailable' | 'error'> {
-  try {
-    const url = baseUrl.replace(/\/+$/, '')
-    const res = await fetch(`${url}/models`, { signal: AbortSignal.timeout(5000) })
-    if (!res.ok) return 'error'
-    const data = (await res.json()) as { data?: { id: string }[] }
-    const ids = (data.data ?? []).map((m) => m.id)
-    return ids.includes(model) ? 'available' : 'unavailable'
-  } catch {
-    return 'error'
-  }
-}
-
-export async function* streamOllamaModelPull(
-  baseUrl: string,
-  model: string,
-  signal?: AbortSignal,
-): AsyncGenerator<number> {
-  const res = await fetch(`${ollamaNativeBase(baseUrl)}/api/pull`, {
-    method: 'POST',
-    signal,
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name: model }),
-  })
-  if (!res.ok) throw new Error(`HTTP ${res.status}`)
-  const reader = res.body!.getReader()
-  const decoder = new TextDecoder()
-  let buffer = ''
-  try {
-    while (true) {
-      const { done, value } = await reader.read()
-      if (done) break
-      buffer += decoder.decode(value, { stream: true })
-      const lines = buffer.split('\n')
-      buffer = lines.pop() ?? ''
-      for (const line of lines) {
-        if (!line.trim()) continue
-        let obj: { error?: string; total?: number; completed?: number }
-        try {
-          obj = JSON.parse(line) as typeof obj
-        } catch {
-          continue // malformed/truncated NDJSON line — don't kill the pull
-        }
-        if (obj.error) throw new Error(obj.error)
-        if (obj.total && obj.completed != null) yield obj.completed / obj.total
-      }
-    }
-  } finally {
-    // Release the connection when the consumer stops early (dialog closed).
-    await reader.cancel().catch(() => {})
-  }
-}
+/** Re-export from the single AI networking boundary. */
+export { isLocalhostUrl, ollamaNativeBase } from '@/llm/completion'

--- a/src/llm/completion.test.ts
+++ b/src/llm/completion.test.ts
@@ -11,7 +11,16 @@ vi.mock('@tauri-apps/plugin-http', () => ({
 
 import { APICallError } from 'ai'
 import type { NessoSettings } from '@/types/graph'
-import { describeCompletionError, fetchCompletion, isAiReady, isNetworkFailure } from './completion'
+import {
+  checkEndpoint,
+  describeCompletionError,
+  fetchCompletion,
+  getConfiguredFetch,
+  isAiReady,
+  isLocalhostUrl,
+  isNetworkFailure,
+  pullModel,
+} from './completion'
 
 const settings = {
   aiBaseUrl: 'http://localhost:11434/v1',
@@ -312,5 +321,426 @@ describe('fetchCompletion streaming', () => {
 
     // Browser fetch must not be called on desktop.
     expect(browserFetch).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getConfiguredFetch
+// ---------------------------------------------------------------------------
+
+describe('getConfiguredFetch', () => {
+  it('returns global fetch in browser mode', () => {
+    vi.stubGlobal('window', {})
+    const browserFetch = vi.fn()
+    vi.stubGlobal('fetch', browserFetch)
+
+    const fetcher = getConfiguredFetch()
+    expect(fetcher).toBe(browserFetch)
+  })
+
+  it('returns a Tauri-delegating function in desktop mode', () => {
+    vi.stubGlobal('window', { __TAURI_INTERNALS__: {} })
+    vi.stubGlobal('fetch', vi.fn())
+
+    const fetcher = getConfiguredFetch()
+    expect(typeof fetcher).toBe('function')
+    // It must not be the global fetch.
+    expect(fetcher).not.toBe(globalThis.fetch)
+  })
+
+  it('the desktop fetcher forwards to @tauri-apps/plugin-http with maxRedirections=0', async () => {
+    vi.stubGlobal('window', { __TAURI_INTERNALS__: {} })
+    vi.stubGlobal('fetch', vi.fn())
+    mockNativeFetch.mockResolvedValue(new Response('ok', { status: 200 }))
+
+    const fetcher = getConfiguredFetch()
+    await fetcher('http://localhost:11434/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    expect(mockNativeFetch).toHaveBeenCalledTimes(1)
+    const [url, init] = mockNativeFetch.mock.calls[0] as [
+      string,
+      { method?: string; headers?: Record<string, string>; maxRedirections?: number },
+    ]
+    expect(url).toBe('http://localhost:11434/v1/chat/completions')
+    expect(init.method).toBe('POST')
+    expect(init.maxRedirections).toBe(0)
+    expect(init.headers).toEqual({ 'Content-Type': 'application/json' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isLocalhostUrl
+// ---------------------------------------------------------------------------
+
+describe('isLocalhostUrl', () => {
+  it('recognizes localhost, 127.0.0.1, [::1], and ::1', () => {
+    expect(isLocalhostUrl('http://localhost:11434/v1')).toBe(true)
+    expect(isLocalhostUrl('http://localhost/v1')).toBe(true)
+    expect(isLocalhostUrl('https://localhost:8080')).toBe(true)
+    expect(isLocalhostUrl('http://127.0.0.1:11434/v1')).toBe(true)
+    expect(isLocalhostUrl('http://127.0.0.1/v1')).toBe(true)
+    expect(isLocalhostUrl('http://[::1]:11434/v1')).toBe(true)
+    expect(isLocalhostUrl('http://[::1]/v1')).toBe(true)
+  })
+
+  it('rejects non-loopback hostnames', () => {
+    expect(isLocalhostUrl('https://opencode.ai/zen/v1')).toBe(false)
+    expect(isLocalhostUrl('https://api.openai.com/v1')).toBe(false)
+    expect(isLocalhostUrl('http://192.168.1.10:11434/v1')).toBe(false)
+    expect(isLocalhostUrl('http://example.com/v1')).toBe(false)
+  })
+
+  it('handles invalid URLs gracefully', () => {
+    expect(isLocalhostUrl('not-a-url')).toBe(false)
+    expect(isLocalhostUrl('')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// checkEndpoint
+// ---------------------------------------------------------------------------
+
+describe('checkEndpoint', () => {
+  it('uses browser fetch in non-desktop mode', async () => {
+    vi.stubGlobal('window', {})
+    const browserFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ id: 'gemma3:4b' }] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', browserFetch)
+
+    const result = await checkEndpoint('http://localhost:11434', 'gemma3:4b', '')
+
+    expect(result).toBe('available')
+    expect(browserFetch).toHaveBeenCalledTimes(1)
+    const [url] = browserFetch.mock.calls[0] as [string]
+    expect(url).toBe('http://localhost:11434/models')
+    expect(mockNativeFetch).not.toHaveBeenCalled()
+  })
+
+  it('uses Tauri fetch on desktop', async () => {
+    vi.stubGlobal('window', { __TAURI_INTERNALS__: {} })
+    vi.stubGlobal('fetch', vi.fn())
+    mockNativeFetch.mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ id: 'gemma3:4b' }] }), {
+        status: 200,
+      }),
+    )
+
+    const result = await checkEndpoint('http://localhost:11434', 'gemma3:4b', '')
+
+    expect(result).toBe('available')
+    expect(mockNativeFetch).toHaveBeenCalledTimes(1)
+    expect(globalThis.fetch).not.toHaveBeenCalled?.()
+  })
+
+  it('sends bearer auth when apiKey is provided', async () => {
+    vi.stubGlobal('window', {})
+    const browserFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ id: 'big-pickle' }] }), {
+        status: 200,
+      }),
+    )
+    vi.stubGlobal('fetch', browserFetch)
+
+    await checkEndpoint('https://opencode.ai/zen/v1', 'big-pickle', 'test-key')
+
+    const [, init] = browserFetch.mock.calls[0] as [string, RequestInit]
+    expect(new Headers(init.headers).get('authorization')).toBe('Bearer test-key')
+  })
+
+  it('does not send auth header when apiKey is empty', async () => {
+    vi.stubGlobal('window', {})
+    const browserFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ id: 'gemma3:4b' }] }), {
+        status: 200,
+      }),
+    )
+    vi.stubGlobal('fetch', browserFetch)
+
+    await checkEndpoint('http://localhost:11434', 'gemma3:4b', '')
+
+    const [, init] = browserFetch.mock.calls[0] as [string, RequestInit]
+    expect(new Headers(init.headers).get('authorization')).toBeNull()
+  })
+
+  it('returns available when model is in the /models list', async () => {
+    vi.stubGlobal('window', {})
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ data: [{ id: 'gemma3:4b' }, { id: 'llama3.2:3b' }] }), {
+          status: 200,
+        }),
+      ),
+    )
+
+    const result = await checkEndpoint('http://localhost:11434', 'gemma3:4b', '')
+    expect(result).toBe('available')
+  })
+
+  it('returns unavailable when model is not in the /models list', async () => {
+    vi.stubGlobal('window', {})
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(JSON.stringify({ data: [{ id: 'llama3.2:3b' }] }), { status: 200 }),
+        ),
+    )
+
+    const result = await checkEndpoint('http://localhost:11434', 'gemma3:4b', '')
+    expect(result).toBe('unavailable')
+  })
+
+  it('returns unauthorized for 401', async () => {
+    vi.stubGlobal('window', {})
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('unauthorized', { status: 401 })))
+
+    const result = await checkEndpoint('https://opencode.ai/zen/v1', 'big-pickle', 'wrong-key')
+    expect(result).toBe('unauthorized')
+  })
+
+  it('returns unauthorized for 403', async () => {
+    vi.stubGlobal('window', {})
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('forbidden', { status: 403 })))
+
+    const result = await checkEndpoint('https://opencode.ai/zen/v1', 'big-pickle', 'bad-key')
+    expect(result).toBe('unauthorized')
+  })
+
+  it('returns error for 500 server error', async () => {
+    vi.stubGlobal('window', {})
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('server error', { status: 500 })))
+
+    const result = await checkEndpoint('https://opencode.ai/zen/v1', 'big-pickle', 'test-key')
+    expect(result).toBe('error')
+  })
+
+  it('returns error for 404 not found', async () => {
+    vi.stubGlobal('window', {})
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('not found', { status: 404 })))
+
+    const result = await checkEndpoint('https://opencode.ai/zen/v1', 'big-pickle', 'test-key')
+    expect(result).toBe('error')
+  })
+
+  it('returns error for network failures (fetch throws TypeError)', async () => {
+    vi.stubGlobal('window', {})
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')))
+
+    const result = await checkEndpoint('http://localhost:11434', 'gemma3:4b', '')
+    expect(result).toBe('error')
+  })
+
+  it('strips trailing slashes from the base URL', async () => {
+    vi.stubGlobal('window', {})
+    const browserFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ id: 'gemma3:4b' }] }), {
+        status: 200,
+      }),
+    )
+    vi.stubGlobal('fetch', browserFetch)
+
+    await checkEndpoint('http://localhost:11434/v1/', 'gemma3:4b', '')
+
+    const [url] = browserFetch.mock.calls[0] as [string]
+    expect(url).toBe('http://localhost:11434/v1/models')
+  })
+
+  it('sends a composed signal to fetch when a caller signal is provided', async () => {
+    vi.stubGlobal('window', { __TAURI_INTERNALS__: {} })
+    vi.stubGlobal('fetch', vi.fn())
+    mockNativeFetch.mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ id: 'gemma3:4b' }] }), { status: 200 }),
+    )
+
+    const controller = new AbortController()
+    await checkEndpoint('http://localhost:11434', 'gemma3:4b', '', controller.signal)
+
+    const [, init] = mockNativeFetch.mock.calls[0] as [string, RequestInit]
+    // The signal is composed (caller signal + 5s timeout), not the raw caller signal.
+    expect(init.signal).not.toBe(controller.signal)
+    expect(init.signal).toBeInstanceOf(AbortSignal)
+    // A non-aborted composed signal must not appear pre-aborted.
+    expect(init.signal?.aborted).toBe(false)
+  })
+
+  it('applies a 5-second timeout when no signal is provided', async () => {
+    vi.stubGlobal('window', {})
+    const browserFetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ data: [{ id: 'gemma3:4b' }] }), { status: 200 }),
+      )
+    vi.stubGlobal('fetch', browserFetch)
+
+    await checkEndpoint('http://localhost:11434', 'gemma3:4b', '')
+
+    const [, init] = browserFetch.mock.calls[0] as [string, RequestInit]
+    // When no signal is provided, the function should create a timeout signal.
+    expect(init.signal).toBeInstanceOf(AbortSignal)
+    // The timeout signal should not be the same as a fresh controller's signal
+    // (it was created internally with AbortSignal.timeout).
+    const freshCtrl = new AbortController()
+    expect(init.signal).not.toBe(freshCtrl.signal)
+  })
+
+  it('composes a caller-provided signal with the 5-second timeout so the check cannot stay stuck', async () => {
+    vi.stubGlobal('window', {})
+    const browserFetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ data: [{ id: 'gemma3:4b' }] }), { status: 200 }),
+      )
+    vi.stubGlobal('fetch', browserFetch)
+
+    const controller = new AbortController()
+    await checkEndpoint('http://localhost:11434', 'gemma3:4b', '', controller.signal)
+
+    const [, init] = browserFetch.mock.calls[0] as [string, RequestInit]
+    // The composed signal is not the caller's raw signal — it bundles both
+    // the caller's controller and an internal 5-second timeout so the check
+    // cannot stay stuck in "checking" indefinitely even with a caller signal.
+    expect(init.signal).not.toBe(controller.signal)
+    expect(init.signal).toBeInstanceOf(AbortSignal)
+    // The fresh controller's signal is a different object.
+    const freshCtrl = new AbortController()
+    expect(init.signal).not.toBe(freshCtrl.signal)
+  })
+
+  it('caller abort still propagates through the composed signal', async () => {
+    vi.stubGlobal('window', {})
+    const controller = new AbortController()
+    controller.abort() // abort before call
+
+    // fetch should throw AbortError when called with an already-aborted signal
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new DOMException('The operation was aborted.', 'AbortError')),
+    )
+
+    const result = await checkEndpoint('http://localhost:11434', 'gemma3:4b', '', controller.signal)
+    expect(result).toBe('error')
+  })
+
+  it('resolves to error when the caller aborts the signal before fetch completes', async () => {
+    vi.stubGlobal('window', {})
+    const controller = new AbortController()
+    controller.abort() // abort before call
+
+    // fetch should throw AbortError when called with an already-aborted signal
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new DOMException('The operation was aborted.', 'AbortError')),
+    )
+
+    const result = await checkEndpoint('http://localhost:11434', 'gemma3:4b', '', controller.signal)
+    expect(result).toBe('error')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// pullModel
+// ---------------------------------------------------------------------------
+
+describe('pullModel', () => {
+  function ndjsonChunks(lines: string[]): Response {
+    const encoder = new TextEncoder()
+    const body = lines.map((l) => encoder.encode(l + '\n'))
+    const stream = new ReadableStream<Uint8Array>({
+      start(ctrl) {
+        for (const chunk of body) ctrl.enqueue(chunk)
+        ctrl.close()
+      },
+    })
+    return new Response(stream, { status: 200 })
+  }
+
+  it('yields progress from NDJSON stream lines', async () => {
+    vi.stubGlobal('window', {})
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          ndjsonChunks([
+            JSON.stringify({ total: 100, completed: 25 }),
+            JSON.stringify({ total: 100, completed: 50 }),
+          ]),
+        ),
+    )
+
+    const progress: number[] = []
+    for await (const p of pullModel('http://localhost:11434', 'gemma3:4b')) {
+      progress.push(p)
+    }
+    expect(progress).toEqual([0.25, 0.5])
+  })
+
+  it('passes AbortSignal to the underlying fetch', async () => {
+    vi.stubGlobal('window', { __TAURI_INTERNALS__: {} })
+    vi.stubGlobal('fetch', vi.fn())
+    mockNativeFetch.mockResolvedValue(ndjsonChunks([]))
+
+    const controller = new AbortController()
+    const gen = pullModel('http://localhost:11434', 'gemma3:4b', controller.signal)
+    // consume the generator
+    for await (const _ of gen) {
+      void _
+    }
+
+    expect(mockNativeFetch).toHaveBeenCalledTimes(1)
+    const [, init] = mockNativeFetch.mock.calls[0] as [string, RequestInit]
+    expect(init.signal).toBe(controller.signal)
+  })
+
+  it('throws on non-2xx response', async () => {
+    vi.stubGlobal('window', {})
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('not found', { status: 404 })))
+
+    await expect(async () => {
+      for await (const _ of pullModel('http://localhost:11434', 'gemma3:4b')) {
+        void _
+      }
+    }).rejects.toThrow('HTTP 404')
+  })
+
+  it('throws on error in NDJSON line', async () => {
+    vi.stubGlobal('window', {})
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(ndjsonChunks([JSON.stringify({ error: 'something broke' })])),
+    )
+
+    await expect(async () => {
+      for await (const _ of pullModel('http://localhost:11434', 'gemma3:4b')) {
+        void _
+      }
+    }).rejects.toThrow('something broke')
+  })
+
+  it('skips malformed NDJSON lines gracefully', async () => {
+    vi.stubGlobal('window', {})
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          ndjsonChunks(['not-json{{{', JSON.stringify({ total: 200, completed: 100 })]),
+        ),
+    )
+
+    const progress: number[] = []
+    for await (const p of pullModel('http://localhost:11434', 'gemma3:4b')) {
+      progress.push(p)
+    }
+    expect(progress).toEqual([0.5]) // malformed line skipped, valid one parsed
   })
 })

--- a/src/llm/completion.ts
+++ b/src/llm/completion.ts
@@ -23,10 +23,201 @@ export function isAiReady(settings: NessoSettings): boolean {
   return Boolean(settings.aiBaseUrl && settings.aiModel)
 }
 
-const desktopFetch: typeof globalThis.fetch = async (input, init) => {
+// ---------------------------------------------------------------------------
+// Platform adapter — single boundary for all AI HTTP I/O
+// ---------------------------------------------------------------------------
+
+const _desktopFetch: typeof globalThis.fetch = async (input, init) => {
   const { fetch } = await import('@tauri-apps/plugin-http')
   return fetch(input, { ...init, maxRedirections: 0 })
 }
+
+/**
+ * Returns the platform-appropriate fetch implementation:
+ * Tauri's native HTTP client on desktop (with maxRedirections: 0),
+ * or the browser's global fetch otherwise.
+ */
+export function getConfiguredFetch(): typeof globalThis.fetch {
+  return isDesktop() ? _desktopFetch : globalThis.fetch
+}
+
+/**
+ * Returns true when the URL's hostname is a loopback address:
+ * `localhost`, `127.0.0.1`, `::1`, or `[::1]`.
+ * Invalid URLs return false.
+ */
+export function isLocalhostUrl(url: string): boolean {
+  try {
+    const hostname = new URL(url).hostname
+    return (
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1' ||
+      hostname === '::1' ||
+      hostname === '[::1]'
+    )
+  } catch {
+    return false
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint health check (OpenAI-compatible /models)
+// ---------------------------------------------------------------------------
+
+/**
+ * Checks whether a model is available at the given base URL by querying the
+ * `/models` endpoint. Returns one of:
+ * - `'available'`   — model found in the list
+ * - `'unavailable'` — endpoint reachable, list returned, but model not present
+ * - `'unauthorized'` — HTTP 401 or 403
+ * - `'error'`       — network failure, timeout, or any other non-2xx response
+ *
+ * When the caller provides a signal it is passed straight through to fetch.
+ * When no signal is given a 5-second timeout is applied internally.
+ */
+export async function checkEndpoint(
+  baseUrl: string,
+  model: string,
+  apiKey: string,
+  signal?: AbortSignal,
+): Promise<'available' | 'unavailable' | 'unauthorized' | 'error'> {
+  try {
+    const cleanUrl = baseUrl.replace(/\/+$/, '')
+    const fetcher = getConfiguredFetch()
+    const headers: Record<string, string> = {}
+    if (apiKey) {
+      headers['Authorization'] = `Bearer ${apiKey}`
+    }
+    const effectiveSignal = signal
+      ? AbortSignal.any([signal, AbortSignal.timeout(5000)])
+      : AbortSignal.timeout(5000)
+    const res = await fetcher(`${cleanUrl}/models`, {
+      signal: effectiveSignal,
+      headers,
+    })
+    if (res.status === 401 || res.status === 403) return 'unauthorized'
+    if (!res.ok) return 'error'
+    const data = (await res.json()) as { data?: { id: string }[] }
+    const ids = (data.data ?? []).map((m) => m.id)
+    return ids.includes(model) ? 'available' : 'unavailable'
+  } catch {
+    return 'error'
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Native Ollama model pull (streaming NDJSON progress)
+// ---------------------------------------------------------------------------
+
+/**
+ * Strips trailing slashes and an optional `/v1` suffix from an OpenAI-compatible
+ * base URL, yielding the native Ollama base URL (e.g. for `/api/pull`).
+ */
+export function ollamaNativeBase(aiBaseUrl: string): string {
+  return aiBaseUrl.replace(/\/+$/, '').replace(/\/v1$/, '')
+}
+
+/**
+ * Async-generator that yields individual lines as they arrive from a
+ * ReadableStream of Uint8Array chunks. Handles buffering of partial lines
+ * across chunk boundaries.
+ */
+async function* _readChunkLines(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): AsyncGenerator<string> {
+  const decoder = new TextDecoder()
+  let buffer = ''
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+    const lines = buffer.split('\n')
+    buffer = lines.pop() ?? ''
+    yield* lines
+  }
+}
+
+/**
+ * Parses one NDJSON line from an Ollama pull stream. Returns a progress
+ * fraction (0–1), or null if the line should be skipped (blank, malformed,
+ * or missing progress fields). Throws on `{"error": "…"}` entries.
+ */
+function _parsePullLine(line: string): number | null {
+  const trimmed = line.trim()
+  if (!trimmed) return null
+  let obj: { error?: string; total?: number; completed?: number }
+  try {
+    obj = JSON.parse(trimmed) as typeof obj
+  } catch {
+    return null // malformed/truncated NDJSON line — don't kill the pull
+  }
+  if (obj.error) throw new Error(obj.error)
+  if (obj.total && obj.completed != null) return obj.completed / obj.total
+  return null
+}
+
+/**
+ * Streams a native Ollama model pull via `/api/pull`, yielding progress
+ * fractions (0–1). Throws on non-2xx responses or error entries in the
+ * NDJSON stream. The consumer should use the AbortSignal to cancel the
+ * pull (e.g. when the settings dialog closes).
+ */
+export async function* pullModel(
+  baseUrl: string,
+  model: string,
+  signal?: AbortSignal,
+): AsyncGenerator<number> {
+  const fetcher = getConfiguredFetch()
+  const nativeBase = ollamaNativeBase(baseUrl)
+  const res = await fetcher(`${nativeBase}/api/pull`, {
+    method: 'POST',
+    signal,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: model }),
+  })
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  const reader = res.body!.getReader()
+  try {
+    for await (const line of _readChunkLines(reader)) {
+      const progress = _parsePullLine(line)
+      if (progress !== null) yield progress
+    }
+  } finally {
+    // Release the connection when the consumer stops early (dialog closed).
+    await reader.cancel().catch(() => {})
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pull orchestrator — drives progress callback, handles abort/error
+// ---------------------------------------------------------------------------
+
+/**
+ * Pulls a model via pullModel, calling onProgress with each fraction (0–1).
+ * Returns true when the pull completes successfully, false when the signal
+ * was aborted or an error occurred. The caller uses the returned boolean to
+ * decide the final UI status.
+ */
+export async function executeModelPull(
+  baseUrl: string,
+  model: string,
+  signal: AbortSignal,
+  onProgress: (fraction: number) => void,
+): Promise<boolean> {
+  try {
+    for await (const fraction of pullModel(baseUrl, model, signal)) {
+      if (signal.aborted) return false
+      onProgress(fraction)
+    }
+    return !signal.aborted
+  } catch {
+    return false
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Streaming completion (mentor chat) — existing
+// ---------------------------------------------------------------------------
 
 /**
  * Wraps the configured OpenAI-compatible endpoint with reasoning extraction so
@@ -38,7 +229,7 @@ function mentorModel(settings: NessoSettings) {
     name: 'nesso-mentor',
     baseURL: settings.aiBaseUrl.replace(/\/+$/, ''),
     ...(settings.aiApiKey ? { apiKey: settings.aiApiKey } : {}),
-    ...(isDesktop() ? { fetch: desktopFetch } : {}),
+    ...(isDesktop() ? { fetch: _desktopFetch } : {}),
   })
   return wrapLanguageModel({
     model: provider.chatModel(settings.aiModel),


### PR DESCRIPTION
## Summary

Fixes desktop mentor requests failing during Tauri HTTP capability deserialization, and make the Settings AI endpoint status use the same authenticated transport as mentor requests.

Closes #134

## Changes

- Escape IPv6 loopback colons in the Tauri HTTP capability scope and add a native Rust regression test covering HTTPS and loopback endpoints.
- Centralize browser/Tauri AI networking in `src/llm/completion.ts`, including endpoint checks and local Ollama pulls.
- Add authenticated status handling, IPv6 loopback detection, cancellation, and stale-result protection for Settings AI checks and pulls.
- Document endpoint statuses and local-only Ollama pulls in the AI mentor and troubleshooting guides; rebuild the MCP documentation bundle.
- Correct static-analysis guidance for semantic capability-pattern validation.

## Checklist

- [x] Branch name follows the naming convention
- [x] `## [Unreleased]` in `CHANGELOG.md` updated

## Testing

- `pnpm run preflight -- --rust` — 16/16 checks passed.
- 460 Vitest tests across 43 files passed.
- Rust format, Clippy, check, and tests passed.
- Tauri debug build and Playwright E2E passed.
- Review was explicitly skipped at the user's request.