### PR TITLE
feat(harness): persist review reports for re-review context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ yarn.lock
 # Plans (ephemeral, per-session)
 .plans/
 
+# Reviews (ephemeral, per-session)
+.reviews/
+
 # Test / coverage
 coverage
 

--- a/.opencode/agents/guard-review.md
+++ b/.opencode/agents/guard-review.md
@@ -39,6 +39,14 @@ Use `git diff`, `git diff origin/main...HEAD`, and read changed files as needed.
 
 CI deterministically gates the mechanical layer, so don't spend review effort there: **Biome** (format + lint; Prettier only formats Markdown/YAML/HTML), **`tsc`** + **`type-coverage`** (strict, gated at 99%), and **fallow** — `analyze:dead-code` is zero-tolerance on unused files/exports/types/dependencies **and** architecture cycles (circular deps, re-export cycles); `analyze:dupes` and `analyze:health` are identity-baseline ratchets (`fallow-baselines/`) that fail on **new** clones / complex functions. Don't re-review formatting, lint, dead code, duplication, complexity, or type regressions — focus on the **semantic** constraints below, which no tool sees.
 
+## Previous findings (re-review only)
+
+If the calling agent includes findings from a previous review cycle, verify each one against the current diff:
+
+- **Fixed correctly** → do not re-report.
+- **Not fixed or fixed incorrectly** → report as BLOCKING (was previously found, still broken). Include the original `file:line` and note what's wrong with the fix.
+- **New issues** → report as usual per severity mapping below.
+
 ## Severity mapping
 
 - **BLOCKING** — any violation of a hard constraint from `AGENTS.md` → **Constraints**. These are non-negotiable; every hard rule in that section is BLOCKING.

--- a/.opencode/agents/quality-review.md
+++ b/.opencode/agents/quality-review.md
@@ -24,6 +24,14 @@ You do not need to know project-specific constraints — that is the `guard-revi
 
 Use `git diff`, `git diff origin/main...HEAD`, and read changed files as needed. Stay within the changed surface.
 
+## Previous findings (re-review only)
+
+If the calling agent includes findings from a previous review cycle, verify each one against the current diff:
+
+- **Fixed correctly** → do not re-report.
+- **Not fixed or fixed incorrectly** → report as BLOCKING. Include the original `file:line` and note what's wrong with the fix.
+- **New issues** → report as usual per rubric below.
+
 ## Review rubric
 
 ### Correctness — any finding is BLOCKING

--- a/.opencode/agents/work.md
+++ b/.opencode/agents/work.md
@@ -16,6 +16,7 @@ permission:
   edit:
     '*': deny
     .plans/*: allow
+    .reviews/*: allow
   task: allow
 description: Post-issue orchestrator. Routes the development flow from planning to PR. Dispatches plan, build subagents and loads the review skill at the review phase. Creates PR via skill after review passes. Asks for user approval at gates. May persist generated plans under .plans/ but never writes production code directly.
 ---
@@ -79,7 +80,7 @@ GitHub Issue → plan (read-only subagent) → work persists plan → [user appr
    - Review is required for every non-trivial change.
    - A change is trivial only when it is narrowly scoped to documentation, rules, formatting, or another mechanical edit with no runtime, security, dependency, data, or API behavior impact, and preflight is green.
    - For a potentially trivial change, explain the criteria and **suggest** that the user may skip review. Do not skip silently; wait for the user's explicit choice.
-   - If the user chooses review, load the **`review`** skill and follow it — it orchestrates `guard-review` and `quality-review` in parallel and synthesizes a verdict.
+   - If the user chooses review, load the **`review`** skill and follow it — it orchestrates `guard-review` and `quality-review` in parallel and synthesizes a verdict. After the skill returns, persist the report to `.reviews/<issue-number>-review-<N>.md` (N = 1 for the first review, incrementing on each re-review).
    - If the user explicitly chooses to skip review, record that decision in the summary and continue to the publish approval gate. Skipping review never implies approval to commit, push, or open a PR.
    - If a review has already started, its fix loop remains in force: user-approved review fixes require preflight and another review before publishing.
 
@@ -96,7 +97,7 @@ GitHub Issue → plan (read-only subagent) → work persists plan → [user appr
 
    The user always decides. The agent recommends; never loop silently.
 
-4. **If the user confirms build directly**: dispatch `build` for each suggested fix, then re-run preflight and re-run review. Do not commit during this fix loop. If the new review still has findings, loop at step 3 again. This applies whenever a review has run; a skipped review does not create a silent review loop.
+4. **If the user confirms build directly**: dispatch `build` for each suggested fix, then re-run preflight and re-run review. When re-running review, pass the most recent review report path (`.reviews/<issue-number>-review-<N>.md`) so sub-agents verify previous findings were fixed and do not re-report resolved issues. Do not commit during this fix loop. If the new review still has findings, loop at step 3 again. This applies whenever a review has run; a skipped review does not create a silent review loop.
 5. **If ready to PR** and the user explicitly says "ship it" / "go ahead": update `## [Unreleased]` in `CHANGELOG.md` per `.rules/changelog.md`, commit the complete working tree with a concise conventional commit message, then load the **`create-pr`** skill with `--auto` and follow it to push, open the PR, and enable auto-merge. Never commit or push before this approval gate; `create-pr` proceeds without further confirmation.
 
 ## Phase Table

--- a/.opencode/skills/review/SKILL.md
+++ b/.opencode/skills/review/SKILL.md
@@ -16,6 +16,8 @@ Any agent can load this skill to run a pre-PR review. `work` loads it at the rev
 
 This skill orchestrates; it never commits or pushes (see AGENTS.md → Git).
 
+If the calling agent provides a path to a previous review report (e.g. `.reviews/<issue>-review-1.md`), read it and pass each finding to the sub-agents so they can verify fixes were applied and avoid re-reporting resolved issues.
+
 ## 1. Gather the diff
 
 ```bash
@@ -32,7 +34,7 @@ Use the `task` tool to dispatch both subagents simultaneously:
 - `subagent_type: "guard-review"` — reads AGENTS.md Constraints, `.rules/` conventions, cross-cutting obligations
 - `subagent_type: "quality-review"` — reviews the diff for correctness, security, design, performance
 
-Both receive the same diff scope. Each returns a findings report.
+Both receive the same diff scope. If previous findings were provided, include them in each subagent's prompt so they verify fixes and skip resolved issues. Each returns a findings report.
 
 ## 3. Synthesize one verdict
 
@@ -67,3 +69,5 @@ Project-specific convention deviations (from `guard-review`): non-functional com
 Rules sync gaps and docs/MCP parity gaps (from `guard-review`).
 
 If a section is empty, say so in one line. Do not restate the diff.
+
+Wrap the entire consolidated report in `<!-- REVIEW_START -->` / `<!-- REVIEW_END -->` markers so the calling agent can extract and persist it.

--- a/opencode.json
+++ b/opencode.json
@@ -19,9 +19,9 @@
   },
   "agent": {
     "brainstorm": {
-      "model": "openai/gpt-5.6-luna",
-      "reasoningEffort": "xhigh",
-      "variant": "xhigh"
+      "model": "openai/gpt-5.6-sol",
+      "reasoningEffort": "high",
+      "variant": "high"
     },
     "fix": {
       "model": "openai/gpt-5.6-sol",
@@ -30,13 +30,13 @@
     },
     "guard-review": {
       "model": "openai/gpt-5.6-luna",
-      "reasoningEffort": "xhigh",
-      "variant": "xhigh"
+      "reasoningEffort": "high",
+      "variant": "high"
     },
     "quality-review": {
       "model": "openai/gpt-5.6-luna",
-      "reasoningEffort": "xhigh",
-      "variant": "xhigh"
+      "reasoningEffort": "high",
+      "variant": "high"
     },
     "work": {
       "model": "openai/gpt-5.6-luna",
@@ -44,16 +44,16 @@
       "variant": "xhigh"
     },
     "plan": {
-      "model": "openai/gpt-5.6-luna",
-      "reasoningEffort": "max",
-      "variant": "max"
+      "model": "openai/gpt-5.6-terra",
+      "reasoningEffort": "high",
+      "variant": "high"
     },
     "build": {
       "model": "opencode-go/deepseek-v4-pro",
       "variant": "high"
     },
     "harness": {
-      "model": "openai/gpt-5.6-luna",
+      "model": "opencode-go/deepseek-v4-pro",
       "reasoningEffort": "high",
       "variant": "high"
     }


### PR DESCRIPTION
## Summary

The review flow now persists each cycle's findings to `.reviews/` (like `.plans/` for planning) and passes previous findings into re-review cycles so sub-agents can verify fixes and avoid re-reporting resolved issues.

## Changes

- **Review report persistence:** `work` persists the synthesized review report to `.reviews/<issue>-review-<N>.md` after each cycle (`.gitignore`d, ephemeral like `.plans/`)
- **Previous findings handoff:** on re-review, `work` passes the previous report path to the `review` skill, which forwards findings to `guard-review` and `quality-review`
- **Sub-agent verification:** both review sub-agents now verify previous findings — fixed correctly items are not re-reported; unfixed or incorrectly fixed items escalate to BLOCKING
- **Structured output:** review reports use `REVIEW_START`/`REVIEW_END` markers so the orchestrator can extract and persist them
- **Agent model tuning:** `opencode.json` model assignments tuned (sol for brainstorm/fix, terra for plan, deepseek for harness)

## Checklist

- [x] Branch name follows the naming convention
- [ ] `## [Unreleased]` in `CHANGELOG.md` updated — not needed (harness-only per `.rules/changelog.md`)

## Testing

Harness files only — no runtime or product code changes. Verified with a coherence sweep: all invariants pass (bijection, touch→update, links, skills/subagents).