### PR TITLE
feat(github): refresh native issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,19 +1,16 @@
 name: Bug report
-description: Something is broken or behaving unexpectedly
+description: Report existing behavior that is broken or unexpected
 type: Bug
 body:
-  - type: input
-    id: summary
+  - type: markdown
     attributes:
-      label: Summary
-      description: One sentence describing what went wrong.
-    validations:
-      required: true
+      value: Use this form when existing behavior is incorrect. Request new behavior with a Feature; use Refactor for internal changes that preserve behavior.
 
   - type: textarea
-    id: steps
+    id: observed
     attributes:
-      label: Steps to reproduce
+      label: Observed behavior and reproduction
+      description: What happened, and what is the smallest reliable way to reproduce it?
       placeholder: |
         1.
         2.
@@ -24,15 +21,15 @@ body:
   - type: textarea
     id: expected
     attributes:
-      label: Expected vs actual behavior
-      placeholder: "Expected: ...\nActual: ..."
+      label: Expected behavior
+      description: What should have happened instead?
     validations:
       required: true
 
   - type: textarea
     id: context
     attributes:
-      label: Environment
-      placeholder: 'OS, browser or Tauri desktop, Nesso version, AI backend (Ollama / remote).'
+      label: Environment and context (optional)
+      description: Include the OS, browser or Tauri desktop, Nesso version, screenshots, logs, or other relevant context.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,43 @@
+name: Documentation
+description: Report a documentation gap or propose a focused docs improvement
+type: Docs
+body:
+  - type: textarea
+    id: gap
+    attributes:
+      label: Documentation gap
+      description: What is missing, unclear, inaccurate, or difficult to find, and who is affected?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed documentation change
+      description: Describe the content or structure that would close the gap.
+    validations:
+      required: true
+
+  - type: textarea
+    id: source-of-truth
+    attributes:
+      label: Source of truth (optional)
+      description: Which implementation, behavior, rule, or external reference should the docs match?
+    validations:
+      required: false
+
+  - type: textarea
+    id: affected-pages
+    attributes:
+      label: Affected pages (optional)
+      description: Known file paths, URLs, or sections that should change.
+    validations:
+      required: false
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope and context (optional)
+      description: Related issues, audience constraints, follow-ups, or explicit exclusions.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,27 +1,39 @@
 name: Feature request
-description: Propose a new feature or improvement
+description: Propose new or changed user-visible behavior
 type: Feature
 body:
+  - type: markdown
+    attributes:
+      value: Use this form when Nesso should gain or change behavior. Report incorrect existing behavior as a Bug; use Refactor for internal changes that preserve behavior.
+
   - type: textarea
     id: problem
     attributes:
       label: Problem or motivation
-      description: What are you trying to do that you can't do today?
+      description: What are you trying to do that Nesso does not support today, and who is affected?
     validations:
       required: true
 
   - type: textarea
     id: proposal
     attributes:
-      label: Proposed solution
-      description: Describe the behavior you'd like. Sketches or mockups are welcome.
+      label: Proposed change
+      description: Describe the behavior you would like. Sketches or mockups are welcome when useful.
     validations:
       required: true
 
   - type: textarea
     id: alternatives
     attributes:
-      label: Alternatives considered
-      description: Other approaches you thought about, and why you prefer the one above.
+      label: Alternatives considered (optional)
+      description: Other approaches considered and why this proposal is preferable.
+    validations:
+      required: false
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope (optional)
+      description: Dependencies, follow-ups, rollout constraints, or explicit exclusions.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/graph_model.yml
+++ b/.github/ISSUE_TEMPLATE/graph_model.yml
@@ -11,7 +11,7 @@ body:
   - type: textarea
     id: motivation
     attributes:
-      label: Motivation
+      label: Problem or motivation
       description: What concept or learning relationship is currently missing or misrepresented? Include a few concrete cases where the existing 52 types fall short.
     validations:
       required: true
@@ -19,7 +19,7 @@ body:
   - type: textarea
     id: proposal
     attributes:
-      label: Proposal — type definition
+      label: Proposed type definition
       description: |
         Describe the new or modified relation type(s). For each, include:
 

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,0 +1,47 @@
+name: Refactor
+description: Improve internal structure without changing user-visible behavior
+type: Refactor
+body:
+  - type: markdown
+    attributes:
+      value: Use this form for internal changes that preserve behavior. Report incorrect behavior as a Bug; request new behavior as a Feature.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Maintenance problem
+      description: What structure, duplication, coupling, or maintenance cost needs improvement?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed refactor
+      description: Describe the focused internal change and the boundaries it should respect.
+    validations:
+      required: true
+
+  - type: textarea
+    id: behavior-preservation
+    attributes:
+      label: Behavior-preservation plan
+      description: Which externally observable behavior must remain unchanged, and how will you verify it?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered (optional)
+      description: Other approaches considered and why this refactor is preferable.
+    validations:
+      required: false
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope (optional)
+      description: Relevant files, dependencies, follow-ups, or explicit exclusions.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/tooling.yml
+++ b/.github/ISSUE_TEMPLATE/tooling.yml
@@ -6,7 +6,7 @@ body:
     id: problem
     attributes:
       label: Problem or friction
-      description: What developer friction, quality gap, or maintenance cost are you addressing? What can't you catch or do today?
+      description: What developer friction, quality gap, or maintenance cost needs attention?
     validations:
       required: true
 
@@ -14,30 +14,30 @@ body:
     id: proposal
     attributes:
       label: Proposed tooling or change
-      description: Which tool or change, and how it runs (command, config). Link the tool if it is external.
+      description: Which focused tool or change do you propose? Include commands, configuration, or links when relevant.
     validations:
       required: true
 
   - type: textarea
     id: integration
     attributes:
-      label: Integration points
-      description: Where it hooks in — CI (`.github/workflows`), `preflight`, git/Claude hooks, local scripts. Does it gate (fail the build) or only report?
-    validations:
-      required: true
-
-  - type: textarea
-    id: alternatives
-    attributes:
-      label: Alternatives and trade-offs
-      description: Other tools or approaches considered, and why you prefer this one — speed, lock-in, maintenance cost, ecosystem.
+      label: Integration and validation (optional)
+      description: Where should this connect, and how should it be verified? Note CI, preflight, or rollout effects when relevant.
     validations:
       required: false
 
   - type: textarea
-    id: rollout
+    id: alternatives
     attributes:
-      label: Rollout and scope (optional)
-      description: Incremental adoption, baselines/thresholds, and what is explicitly out of scope for a first pass.
+      label: Alternatives and trade-offs (optional)
+      description: Other approaches considered and why this one is preferable.
+    validations:
+      required: false
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope (optional)
+      description: Dependencies, adoption constraints, follow-ups, or explicit exclusions.
     validations:
       required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Changed
+
+- **GitHub Issue Forms:** Refreshed contributor-facing forms with dedicated Refactor and Docs forms plus streamlined Bug, Feature, Tooling, and Graph model prompts across native issue types.
+
 ## [0.2.0-beta.3] - 2026-08-23
 
 ### Added


### PR DESCRIPTION
## Summary

Refresh GitHub Issue Forms into a lean, consistent set covering every native issue type.

Closes #154

## Changes

- add dedicated Refactor and Docs forms with focused required fields
- simplify Bug, Feature, and Tooling prompts while keeping implementation context optional
- align Graph model wording without weakening required semantic evidence or removing its label
- preserve blank issues and document the contributor-facing change in the changelog

## Checklist

- [x] Branch name follows the naming convention
- [x] `## [Unreleased]` in `CHANGELOG.md` updated

## Testing

- `pnpm run preflight` — 12/12 checks passed
- aggregate Ruby YAML and Issue Form shape validation
- repository Prettier YAML check and `git diff --check`